### PR TITLE
#4 - Add support for Number classes (2.0.0)

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,4 @@
+coverage:
+  range: 80..100
+  round: down
+  precision: 2

--- a/README.md
+++ b/README.md
@@ -48,7 +48,10 @@ mockMvc.perform(MockMvcRequestBuilderUtils.postForm("/users", new AddUserForm("J
 ```
 
 ### Register property editor(s)
-Register a PropertyEditor to send properly formatted fields:
+
+This tool relies on default Spring's property editors (see https://github.com/spring-projects/spring-framework/blob/master/spring-beans/src/main/java/org/springframework/beans/PropertyEditorRegistrySupport.java#L200).
+
+If you want to override one of those registered by default, simple use the `MockMvcRequestBuilderUtils.registerPropertyEditor(...)` method:
 ```
 MockMvcRequestBuilderUtils.registerPropertyEditor(LocalDate.class, new CustomLocalDatePropertyEditor("dd/MM/yyyy"));
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.florianlopes</groupId>
     <artifactId>spring-mvc-test-utils</artifactId>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>spring-mvc-test-utils</name>
@@ -24,12 +24,12 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <java.version>1.8</java.version>
-        <commons-lang3.version>3.6</commons-lang3.version>
-        <spring-test.version>5.0.0.RELEASE</spring-test.version>
+        <commons-lang3.version>3.7</commons-lang3.version>
+        <spring-test.version>5.0.2.RELEASE</spring-test.version>
         <junit.version>4.12</junit.version>
-        <lombok.version>1.16.10</lombok.version>
+        <lombok.version>1.16.18</lombok.version>
         <javax.servlet-api.version>3.1.0</javax.servlet-api.version>
-        <spring-webmvc.version>5.0.0.RELEASE</spring-webmvc.version>
+        <spring-webmvc.version>5.0.2.RELEASE</spring-webmvc.version>
         <jacoco-maven-plugin.version>0.7.9</jacoco-maven-plugin.version>
         <maven-compiler-plugin.version>3.7.0</maven-compiler-plugin.version>
         <maven-surefire-plugin.version>2.20.1</maven-surefire-plugin.version>

--- a/src/main/java/io/florianlopes/spring/test/web/servlet/request/MockMvcRequestBuilderUtils.java
+++ b/src/main/java/io/florianlopes/spring/test/web/servlet/request/MockMvcRequestBuilderUtils.java
@@ -96,12 +96,12 @@ public class MockMvcRequestBuilderUtils {
                         map.forEach((key, value) -> formFields.put(getPositionedField(path, field, getStringValue(key)), getStringValue(value)));
                     }
                 } else {
-                    final PropertyEditor fieldPropertyEditor = getPropertyEditorFor(fieldValue);
-                    if (fieldPropertyEditor != null) {
-                        fieldPropertyEditor.setValue(fieldValue);
-                        formFields.put(path + field.getName(), fieldPropertyEditor.getAsText());
+                    if (hasPropertyEditorFor(fieldValue.getClass())) {
+                        // Resolve field's value using property editor
+                        formFields.put(path + field.getName(), getFieldStringValue(form, field));
                     } else {
                         if (isComplexField(field)) {
+                            // Iterate over object's fields
                             final String nestedPath = getNestedPath(field);
                             formFields.putAll(getFormFields(ReflectionTestUtils.getField(form, field.getName()), formFields, nestedPath));
                         } else {
@@ -163,6 +163,11 @@ public class MockMvcRequestBuilderUtils {
             return String.valueOf(object);
         }
         return StringUtils.EMPTY;
+    }
+
+    private static boolean hasPropertyEditorFor(Class<?> type) {
+        return propertyEditorRegistry.hasCustomEditorForElement(type, null) ||
+                propertyEditorRegistry.getDefaultEditor(type) != null;
     }
 
     private static PropertyEditor getPropertyEditorFor(Object object) {

--- a/src/main/java/io/florianlopes/spring/test/web/servlet/request/MockMvcRequestBuilderUtils.java
+++ b/src/main/java/io/florianlopes/spring/test/web/servlet/request/MockMvcRequestBuilderUtils.java
@@ -96,17 +96,13 @@ public class MockMvcRequestBuilderUtils {
                         map.forEach((key, value) -> formFields.put(getPositionedField(path, field, getStringValue(key)), getStringValue(value)));
                     }
                 } else {
-                    if (hasPropertyEditorFor(fieldValue.getClass())) {
-                        // Resolve field's value using property editor
-                        formFields.put(path + field.getName(), getFieldStringValue(form, field));
+                    if (!isComplexField(field) || hasPropertyEditorFor(fieldType)) {
+                        // Resolve field's value either using a property editor or its string representation
+                        formFields.put(path + field.getName(), getStringValue(fieldValue));
                     } else {
-                        if (isComplexField(field)) {
-                            // Iterate over object's fields
-                            final String nestedPath = getNestedPath(field);
-                            formFields.putAll(getFormFields(ReflectionTestUtils.getField(form, field.getName()), formFields, nestedPath));
-                        } else {
-                            formFields.put(path + field.getName(), getFieldStringValue(form, field));
-                        }
+                        // Iterate over object's fields
+                        final String nestedPath = getNestedPath(field);
+                        formFields.putAll(getFormFields(ReflectionTestUtils.getField(form, field.getName()), formFields, nestedPath));
                     }
                 }
             }
@@ -146,10 +142,6 @@ public class MockMvcRequestBuilderUtils {
 
     private static Object getFieldValue(Object form, Field field) {
         return ReflectionTestUtils.getField(form, field.getName());
-    }
-
-    private static String getFieldStringValue(Object object, Field field) {
-        return getStringValue(getFieldValue(object, field));
     }
 
     private static String getStringValue(Object object) {

--- a/src/test/java/io/florianlopes/spring/test/web/servlet/request/AddUserForm.java
+++ b/src/test/java/io/florianlopes/spring/test/web/servlet/request/AddUserForm.java
@@ -1,5 +1,7 @@
 package io.florianlopes.spring.test.web.servlet.request;
 
+import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
@@ -18,12 +20,16 @@ import org.springframework.format.annotation.DateTimeFormat;
 @AllArgsConstructor
 @NoArgsConstructor
 @Data
-public class AddUserForm {
+class AddUserForm {
 
     @NotEmpty
     private String firstName;
     @NotEmpty
     private String name;
+    @NotNull
+    private BigDecimal identificationNumber;
+    @NotNull
+    private BigInteger identificationNumberBigInt;
     @NotNull
     private Gender gender;
     @NotNull
@@ -42,7 +48,7 @@ public class AddUserForm {
     @NotEmpty
     private Map<String, String> metadatas;
 
-    public AddUserForm(String firstName, String name, LocalDate birthDate, Address currentAddress) {
+    AddUserForm(String firstName, String name, LocalDate birthDate, Address currentAddress) {
         this.firstName = firstName;
         this.name = name;
         this.birthDate = birthDate;
@@ -63,7 +69,7 @@ public class AddUserForm {
         @NotNull
         private LocalDate date;
 
-        public Diploma(String name, LocalDate date) {
+        Diploma(String name, LocalDate date) {
             this.name = name;
             this.date = date;
         }
@@ -81,7 +87,7 @@ public class AddUserForm {
         @NotEmpty
         private String city;
 
-        public Address(int streetNumber, String streetName, int postalCode, String city) {
+        Address(int streetNumber, String streetName, int postalCode, String city) {
             this.streetNumber = streetNumber;
             this.streetName = streetName;
             this.postalCode = postalCode;

--- a/src/test/java/io/florianlopes/spring/test/web/servlet/request/CustomLocalDatePropertyEditor.java
+++ b/src/test/java/io/florianlopes/spring/test/web/servlet/request/CustomLocalDatePropertyEditor.java
@@ -1,11 +1,10 @@
 package io.florianlopes.spring.test.web.servlet.request;
 
-import org.apache.commons.lang3.StringUtils;
-
 import java.beans.PropertyEditor;
 import java.beans.PropertyEditorSupport;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * Property editor for {@link java.time.LocalDate}
@@ -19,10 +18,10 @@ import java.time.format.DateTimeFormatter;
  */
 class CustomLocalDatePropertyEditor extends PropertyEditorSupport {
 
-    private LocalDate localDate;
     private final DateTimeFormatter dateTimeFormatter;
+    private LocalDate localDate;
 
-    public CustomLocalDatePropertyEditor(String dateFormatPattern) {
+    CustomLocalDatePropertyEditor(String dateFormatPattern) {
         this.dateTimeFormatter = DateTimeFormatter.ofPattern(dateFormatPattern);
     }
 

--- a/src/test/java/io/florianlopes/spring/test/web/servlet/request/MockMvcRequestBuilderUtilsSmokeTests.java
+++ b/src/test/java/io/florianlopes/spring/test/web/servlet/request/MockMvcRequestBuilderUtilsSmokeTests.java
@@ -1,5 +1,7 @@
 package io.florianlopes.spring.test.web.servlet.request;
 
+import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.time.LocalDate;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -63,6 +65,8 @@ public class MockMvcRequestBuilderUtilsSmokeTests {
                 .usernames(Arrays.asList("john.doe", "jdoe"))
                 .usernamesArray(new String[]{"john.doe", "jdoe"})
                 .gender(AddUserForm.Gender.MALE)
+                .identificationNumber(BigDecimal.ONE)
+                .identificationNumberBigInt(BigInteger.ONE)
                 .currentAddress(new AddUserForm.Address(1, "Street", 5222, "New York"))
                 .formerAddresses(new AddUserForm.Address[]{
                         new AddUserForm.Address(10, "Street", 5222, "Chicago"),

--- a/src/test/java/io/florianlopes/spring/test/web/servlet/request/MockMvcRequestBuilderUtilsTests.java
+++ b/src/test/java/io/florianlopes/spring/test/web/servlet/request/MockMvcRequestBuilderUtilsTests.java
@@ -148,6 +148,7 @@ public class MockMvcRequestBuilderUtilsTests {
         final Map<String, String> metadatas = new HashMap<>();
         metadatas.put("firstName", "John");
         metadatas.put("name", "Doe");
+        metadatas.put("gender", null);
         final AddUserForm addUserForm = AddUserForm.builder()
                 .metadatas(metadatas)
                 .build();
@@ -156,6 +157,7 @@ public class MockMvcRequestBuilderUtilsTests {
 
         assertEquals("John", request.getParameter("metadatas[firstName]"));
         assertEquals("Doe", request.getParameter("metadatas[name]"));
+        assertEquals("", request.getParameter("metadatas[gender]"));
     }
 
     @Test

--- a/src/test/java/io/florianlopes/spring/test/web/servlet/request/MockMvcRequestBuilderUtilsTests.java
+++ b/src/test/java/io/florianlopes/spring/test/web/servlet/request/MockMvcRequestBuilderUtilsTests.java
@@ -1,5 +1,8 @@
 package io.florianlopes.spring.test.web.servlet.request;
 
+import java.beans.PropertyEditorSupport;
+import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
@@ -8,8 +11,10 @@ import java.util.Map;
 import javax.servlet.ServletContext;
 import org.apache.commons.lang3.StringUtils;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import org.junit.Before;
 import org.junit.Test;
+import org.springframework.beans.propertyeditors.CustomNumberEditor;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockServletContext;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
@@ -54,8 +59,8 @@ public class MockMvcRequestBuilderUtilsTests {
 
         assertEquals(StringUtils.EMPTY, request.getParameter("name"));
         assertEquals(StringUtils.EMPTY, request.getParameter("firstName"));
-        assertEquals(StringUtils.EMPTY, request.getParameter("birthDate"));
-        assertEquals(null, request.getParameter("currentAddress.city"));
+        assertNull(request.getParameter("birthDate"));
+        assertNull(request.getParameter("currentAddress.city"));
     }
 
     @Test
@@ -154,38 +159,46 @@ public class MockMvcRequestBuilderUtilsTests {
     }
 
     @Test
-    public void unregisterPropertyEditor() {
-        // Register a property editor and ensure it is used
-        MockMvcRequestBuilderUtils.registerPropertyEditor(LocalDate.class, new CustomLocalDatePropertyEditor(DATE_FORMAT_PATTERN));
-        final LocalDate userBirthDate = LocalDate.of(2016, 8, 29);
-        final AddUserForm addUserForm = new AddUserForm("John", "Doe", userBirthDate, null);
+    public void bigDecimal() {
+        final AddUserForm addUserForm = AddUserForm.builder()
+                .identificationNumber(BigDecimal.TEN)
+                .build();
         final MockHttpServletRequestBuilder mockHttpServletRequestBuilder = MockMvcRequestBuilderUtils.postForm(POST_FORM_URL, addUserForm);
+        final MockHttpServletRequest request = mockHttpServletRequestBuilder.buildRequest(this.servletContext);
 
-        MockHttpServletRequest request = mockHttpServletRequestBuilder.buildRequest(this.servletContext);
-        assertEquals(userBirthDate.format(DateTimeFormatter.ofPattern(DATE_FORMAT_PATTERN)), request.getParameter("birthDate"));
-
-        // Unregister the property editor and ensure it is not used anymore
-        MockMvcRequestBuilderUtils.unregisterPropertyEditor(LocalDate.class);
-        final MockHttpServletRequest secondRequest = MockMvcRequestBuilderUtils.postForm(POST_FORM_URL, addUserForm).buildRequest(this.servletContext);
-
-        assertEquals(String.valueOf(userBirthDate), secondRequest.getParameter("birthDate"));
+        assertEquals("10", request.getParameter("identificationNumber"));
     }
 
     @Test
-    public void unregisterPropertyEditors() {
-        // Register a property editor and ensure it is used
-        MockMvcRequestBuilderUtils.registerPropertyEditor(LocalDate.class, new CustomLocalDatePropertyEditor(DATE_FORMAT_PATTERN));
-        final LocalDate userBirthDate = LocalDate.of(2016, 8, 29);
-        final AddUserForm addUserForm = new AddUserForm("John", "Doe", userBirthDate, null);
+    public void bigInteger() {
+        final AddUserForm addUserForm = AddUserForm.builder()
+                .identificationNumberBigInt(BigInteger.TEN)
+                .build();
         final MockHttpServletRequestBuilder mockHttpServletRequestBuilder = MockMvcRequestBuilderUtils.postForm(POST_FORM_URL, addUserForm);
+        final MockHttpServletRequest request = mockHttpServletRequestBuilder.buildRequest(this.servletContext);
 
-        MockHttpServletRequest request = mockHttpServletRequestBuilder.buildRequest(this.servletContext);
-        assertEquals(userBirthDate.format(DateTimeFormatter.ofPattern(DATE_FORMAT_PATTERN)), request.getParameter("birthDate"));
+        assertEquals("10", request.getParameter("identificationNumberBigInt"));
+    }
 
-        // Unregister all property editors and ensure the previously registered property editor is not used anymore
-        MockMvcRequestBuilderUtils.unregisterPropertyEditors();
-        final MockHttpServletRequest secondRequest = MockMvcRequestBuilderUtils.postForm(POST_FORM_URL, addUserForm).buildRequest(this.servletContext);
+    @Test
+    public void registerPropertyEditor() {
+        try {
+            // Registering a property editor should override default conversion strategy
+            MockMvcRequestBuilderUtils.registerPropertyEditor(BigInteger.class, new PropertyEditorSupport() {
+                @Override
+                public String getAsText() {
+                    return "textValue";
+                }
+            });
 
-        assertEquals(String.valueOf(userBirthDate), secondRequest.getParameter("birthDate"));
+            final AddUserForm build = AddUserForm.builder().identificationNumberBigInt(BigInteger.TEN).build();
+            final MockHttpServletRequestBuilder mockHttpServletRequestBuilder = MockMvcRequestBuilderUtils.postForm(POST_FORM_URL, build);
+
+            MockHttpServletRequest request = mockHttpServletRequestBuilder.buildRequest(this.servletContext);
+            assertEquals("textValue", request.getParameter("identificationNumberBigInt"));
+        } finally {
+            // Restore original property editor
+            MockMvcRequestBuilderUtils.registerPropertyEditor(BigInteger.class, new CustomNumberEditor(BigInteger.class, true));
+        }
     }
 }


### PR DESCRIPTION
- Rely on Spring's default property editors
- Remove custom property editors (use Spring's ones)
- Remove MockMvcRequestBuilderUtils#unregisterPropertyEditor method