### PR TITLE
Add support for adding form params via with(RequestPostProcessor).

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,18 @@ hs_err_pid*
 # IntelliJ
 /out/
 
+### Eclipse / STS ###
+.apt_generated
+.classpath
+.factorypath
+.externalToolBuilders
+.project
+.settings
+.springBeans
+.eclipse-pmd
+/.temp-*
+bin
+
 # mpeltonen/sbt-idea plugin
 .idea_modules/
 

--- a/README.md
+++ b/README.md
@@ -41,10 +41,28 @@ public void testSimpleFields() throws Exception {
 
 Usage with MockMvc:
 ```
-mockMvc.perform(MockMvcRequestBuilderUtils.postForm("/users", new AddUserForm("John", "Doe", null, null)))
-        .andExpect(MockMvcResultMatchers.status().isFound())
-        .andExpect(MockMvcResultMatchers.redirectedUrl("/users"))
-        .andExpect(MockMvcResultMatchers.flash().attribute("message", "success"));
+final AddUserForm addUserForm = new AddUserForm("John", "Doe", null, new Address(1, "Street", 5222, "New York")));
+
+mockMvc.perform(MockMvcRequestBuilderUtils.postForm("/users", addUserForm))
+		.andExpect(MockMvcResultMatchers.model().hasNoErrors());
+```
+
+Using `with()` syntax (`FormRequestPostProcessor`):
+
+```
+final AddUserForm addUserForm = new AddUserForm("John", "Doe", null, new Address(1, "Street", 5222, "New York")));
+
+// POST
+mockMvc.perform(post("/users").with(MockMvcRequestBuilderUtils.form(addUserForm)))
+		.andExpect(MockMvcResultMatchers.model().hasNoErrors());
+
+// GET
+mockMvc.perform(get("/users").with(MockMvcRequestBuilderUtils.form(addUserForm)))
+		.andExpect(MockMvcResultMatchers.model().hasNoErrors());
+		
+// PUT
+mockMvc.perform(put("/users").with(MockMvcRequestBuilderUtils.form(addUserForm)))
+		.andExpect(MockMvcResultMatchers.model().hasNoErrors());
 ```
 
 ### Register property editor(s)

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.florianlopes</groupId>
     <artifactId>spring-mvc-test-utils</artifactId>
-    <version>2.1.0</version>
+    <version>2.2.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>spring-mvc-test-utils</name>

--- a/src/main/java/io/florianlopes/spring/test/web/servlet/request/MockMvcRequestBuilderUtils.java
+++ b/src/main/java/io/florianlopes/spring/test/web/servlet/request/MockMvcRequestBuilderUtils.java
@@ -11,6 +11,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
+
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.reflect.FieldUtils;
 import org.apache.commons.logging.Log;
@@ -21,6 +22,7 @@ import org.springframework.http.MediaType;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.request.RequestPostProcessor;
 import org.springframework.util.ClassUtils;
 import org.springframework.util.CollectionUtils;
 
@@ -76,6 +78,24 @@ public class MockMvcRequestBuilderUtils {
         final MockHttpServletRequestBuilder mockHttpServletRequestBuilder = MockMvcRequestBuilders.put(url)
                 .contentType(MediaType.APPLICATION_FORM_URLENCODED);
         return buildFormFields(form, mockHttpServletRequestBuilder);
+    }
+
+    /**
+     * Implementation of {@link RequestPostProcessor} that adds form parameters to the request before execution.
+     * 
+     * @param form form object to add to the request as parameters
+     * @return RequestPostProcessor
+     */
+    public static RequestPostProcessor formParams(Object form) {
+        final Map<String, String> formFields = getFormFields(form, new TreeMap<>(), StringUtils.EMPTY);
+        return request -> {
+            formFields.forEach((path, value) -> {
+                logger.debug(String.format("Adding form field (%s=%s) to HTTP request parameters", path, value));
+                request.addParameter(path, value);
+            });
+            
+            return request;
+        };
     }
 
     private static MockHttpServletRequestBuilder buildFormFields(Object form, MockHttpServletRequestBuilder mockHttpServletRequestBuilder) {

--- a/src/test/java/io/florianlopes/spring/test/web/servlet/request/MockMvcRequestBuilderUtilsSmokeTests.java
+++ b/src/test/java/io/florianlopes/spring/test/web/servlet/request/MockMvcRequestBuilderUtilsSmokeTests.java
@@ -1,7 +1,6 @@
 package io.florianlopes.spring.test.web.servlet.request;
 
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-
+import static io.florianlopes.spring.test.web.servlet.request.MockMvcRequestBuilderUtils.form;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.time.LocalDate;
@@ -15,12 +14,14 @@ import org.junit.Before;
 import org.junit.Test;
 import org.springframework.stereotype.Controller;
 import org.springframework.test.web.servlet.MockMvc;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 
 /**
  * Created by flopes on 15/04/2018.
@@ -36,31 +37,39 @@ public class MockMvcRequestBuilderUtilsSmokeTests {
         this.mockMvc = MockMvcBuilders.standaloneSetup(new UserController())
                 .setValidator(new LocalValidatorFactoryBean())
                 .build();
+
+        MockMvcRequestBuilderUtils.registerPropertyEditor(LocalDate.class, new CustomLocalDatePropertyEditor(DATE_FORMAT_PATTERN));
     }
 
     @Test
     public void fullTest() throws Exception {
         final AddUserForm addUserForm = getCompletedAddUserForm();
 
-        MockMvcRequestBuilderUtils.registerPropertyEditor(LocalDate.class, new CustomLocalDatePropertyEditor(DATE_FORMAT_PATTERN));
-        final LocalDate bachelorDate = LocalDate.now().minusYears(2);
-        final LocalDate masterDate = LocalDate.now();
-        addUserForm.setDiplomas(Arrays.asList(new AddUserForm.Diploma("License", bachelorDate), new AddUserForm.Diploma("MSC", masterDate)));
-
         this.mockMvc.perform(MockMvcRequestBuilderUtils.postForm("/users", addUserForm))
                 .andExpect(MockMvcResultMatchers.model().hasNoErrors());
     }
     
     @Test
-    public void withParamsFullTest() throws Exception {
+    public void withParamsFullTestGetMethod() throws Exception {
         final AddUserForm addUserForm = getCompletedAddUserForm();
         
-        MockMvcRequestBuilderUtils.registerPropertyEditor(LocalDate.class, new CustomLocalDatePropertyEditor(DATE_FORMAT_PATTERN));
-        final LocalDate bachelorDate = LocalDate.now().minusYears(2);
-        final LocalDate masterDate = LocalDate.now();
-        addUserForm.setDiplomas(Arrays.asList(new AddUserForm.Diploma("License", bachelorDate), new AddUserForm.Diploma("MSC", masterDate)));
-        
-        this.mockMvc.perform(post("/users").with(MockMvcRequestBuilderUtils.formParams(addUserForm)))
+        this.mockMvc.perform(get("/users").with(form(addUserForm)))
+                .andExpect(MockMvcResultMatchers.model().hasNoErrors());
+    }
+
+    @Test
+    public void withParamsFullTestPutMethod() throws Exception {
+        final AddUserForm addUserForm = getCompletedAddUserForm();
+
+        this.mockMvc.perform(put("/users").with(form(addUserForm)))
+                .andExpect(MockMvcResultMatchers.model().hasNoErrors());
+    }
+
+    @Test
+    public void withParamsFullTestPostMethod() throws Exception {
+        final AddUserForm addUserForm = getCompletedAddUserForm();
+
+        this.mockMvc.perform(post("/users").with(form(addUserForm)))
                 .andExpect(MockMvcResultMatchers.model().hasNoErrors());
     }
 
@@ -96,7 +105,7 @@ public class MockMvcRequestBuilderUtilsSmokeTests {
     @Controller
     private class UserController {
 
-        @RequestMapping(value = "/users", method = RequestMethod.POST)
+        @RequestMapping(value = "/users")
         public String addUser(@Valid AddUserForm addUserForm, BindingResult bindingResult) {
             return StringUtils.EMPTY;
         }

--- a/src/test/java/io/florianlopes/spring/test/web/servlet/request/MockMvcRequestBuilderUtilsSmokeTests.java
+++ b/src/test/java/io/florianlopes/spring/test/web/servlet/request/MockMvcRequestBuilderUtilsSmokeTests.java
@@ -1,5 +1,7 @@
 package io.florianlopes.spring.test.web.servlet.request;
 
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.time.LocalDate;
@@ -46,6 +48,19 @@ public class MockMvcRequestBuilderUtilsSmokeTests {
         addUserForm.setDiplomas(Arrays.asList(new AddUserForm.Diploma("License", bachelorDate), new AddUserForm.Diploma("MSC", masterDate)));
 
         this.mockMvc.perform(MockMvcRequestBuilderUtils.postForm("/users", addUserForm))
+                .andExpect(MockMvcResultMatchers.model().hasNoErrors());
+    }
+    
+    @Test
+    public void withParamsFullTest() throws Exception {
+        final AddUserForm addUserForm = getCompletedAddUserForm();
+        
+        MockMvcRequestBuilderUtils.registerPropertyEditor(LocalDate.class, new CustomLocalDatePropertyEditor(DATE_FORMAT_PATTERN));
+        final LocalDate bachelorDate = LocalDate.now().minusYears(2);
+        final LocalDate masterDate = LocalDate.now();
+        addUserForm.setDiplomas(Arrays.asList(new AddUserForm.Diploma("License", bachelorDate), new AddUserForm.Diploma("MSC", masterDate)));
+        
+        this.mockMvc.perform(post("/users").with(MockMvcRequestBuilderUtils.formParams(addUserForm)))
                 .andExpect(MockMvcResultMatchers.model().hasNoErrors());
     }
 

--- a/src/test/java/io/florianlopes/spring/test/web/servlet/request/MockMvcRequestBuilderUtilsTests.java
+++ b/src/test/java/io/florianlopes/spring/test/web/servlet/request/MockMvcRequestBuilderUtilsTests.java
@@ -39,7 +39,7 @@ public class MockMvcRequestBuilderUtilsTests {
     @Test
     public void withParamsNullForm() {
         MockHttpServletRequestBuilder mockHttpServletRequestBuilder = post(POST_FORM_URL)
-                .with(MockMvcRequestBuilderUtils.formParams(null));
+                .with(MockMvcRequestBuilderUtils.form(null));
         final MockHttpServletRequest request = mockHttpServletRequestBuilder.buildRequest(this.servletContext);
         mockHttpServletRequestBuilder.postProcessRequest(request);
 
@@ -49,7 +49,7 @@ public class MockMvcRequestBuilderUtilsTests {
     @Test
     public void withParamsNullAndEmptyFields() {
         MockHttpServletRequestBuilder mockHttpServletRequestBuilder = post(POST_FORM_URL)
-                .with(MockMvcRequestBuilderUtils.formParams(new AddUserForm("", "", null, null)));
+                .with(MockMvcRequestBuilderUtils.form(new AddUserForm("", "", null, null)));
         final MockHttpServletRequest request = mockHttpServletRequestBuilder.buildRequest(this.servletContext);
         mockHttpServletRequestBuilder.postProcessRequest(request);
 
@@ -67,7 +67,7 @@ public class MockMvcRequestBuilderUtilsTests {
                 .build();
         
         MockHttpServletRequestBuilder mockHttpServletRequestBuilder = post(POST_FORM_URL)
-                .with(MockMvcRequestBuilderUtils.formParams(addUserForm));
+                .with(MockMvcRequestBuilderUtils.form(addUserForm));
         final MockHttpServletRequest request = mockHttpServletRequestBuilder.buildRequest(this.servletContext);
         mockHttpServletRequestBuilder.postProcessRequest(request);
 
@@ -82,7 +82,7 @@ public class MockMvcRequestBuilderUtilsTests {
                 .build();
         
         MockHttpServletRequestBuilder mockHttpServletRequestBuilder = post(POST_FORM_URL)
-                .with(MockMvcRequestBuilderUtils.formParams(addUserForm));
+                .with(MockMvcRequestBuilderUtils.form(addUserForm));
         final MockHttpServletRequest request = mockHttpServletRequestBuilder.buildRequest(this.servletContext);
         mockHttpServletRequestBuilder.postProcessRequest(request);
 
@@ -91,7 +91,7 @@ public class MockMvcRequestBuilderUtilsTests {
     }
 
     @Test
-    public void withParamsComplextCollection() {
+    public void withParamsComplexCollection() {
         final AddUserForm addUserForm = AddUserForm.builder().firstName("John").name("Doe").build();
         MockMvcRequestBuilderUtils.registerPropertyEditor(LocalDate.class, new CustomLocalDatePropertyEditor(DATE_FORMAT_PATTERN));
         final LocalDate bachelorDate = LocalDate.now().minusYears(2);
@@ -99,7 +99,7 @@ public class MockMvcRequestBuilderUtilsTests {
         addUserForm.setDiplomas(Arrays.asList(new AddUserForm.Diploma("License", bachelorDate), new AddUserForm.Diploma("MSC", masterDate)));
      
         MockHttpServletRequestBuilder mockHttpServletRequestBuilder = post(POST_FORM_URL)
-                .with(MockMvcRequestBuilderUtils.formParams(addUserForm));
+                .with(MockMvcRequestBuilderUtils.form(addUserForm));
         MockHttpServletRequest request = mockHttpServletRequestBuilder.buildRequest(this.servletContext);
         mockHttpServletRequestBuilder.postProcessRequest(request);
         
@@ -115,7 +115,7 @@ public class MockMvcRequestBuilderUtilsTests {
                 .usernamesArray(new String[]{"john.doe", "jdoe"})
                 .build();
         MockHttpServletRequestBuilder mockHttpServletRequestBuilder = post(POST_FORM_URL)
-                .with(MockMvcRequestBuilderUtils.formParams(addUserForm));
+                .with(MockMvcRequestBuilderUtils.form(addUserForm));
         MockHttpServletRequest request = mockHttpServletRequestBuilder.buildRequest(this.servletContext);
         mockHttpServletRequestBuilder.postProcessRequest(request);
 
@@ -133,7 +133,7 @@ public class MockMvcRequestBuilderUtilsTests {
                 })
                 .build();
         MockHttpServletRequestBuilder mockHttpServletRequestBuilder = post(POST_FORM_URL)
-                .with(MockMvcRequestBuilderUtils.formParams(addUserForm));
+                .with(MockMvcRequestBuilderUtils.form(addUserForm));
         MockHttpServletRequest request = mockHttpServletRequestBuilder.buildRequest(this.servletContext);
         mockHttpServletRequestBuilder.postProcessRequest(request);
 
@@ -147,7 +147,7 @@ public class MockMvcRequestBuilderUtilsTests {
                 .firstName("John").name("Doe").gender(AddUserForm.Gender.MALE)
                 .build();
         MockHttpServletRequestBuilder mockHttpServletRequestBuilder = post(POST_FORM_URL)
-                .with(MockMvcRequestBuilderUtils.formParams(addUserForm));
+                .with(MockMvcRequestBuilderUtils.form(addUserForm));
         MockHttpServletRequest request = mockHttpServletRequestBuilder.buildRequest(this.servletContext);
         mockHttpServletRequestBuilder.postProcessRequest(request);
 
@@ -164,7 +164,7 @@ public class MockMvcRequestBuilderUtilsTests {
                 .metadatas(metadatas)
                 .build();
         MockHttpServletRequestBuilder mockHttpServletRequestBuilder = post(POST_FORM_URL)
-                .with(MockMvcRequestBuilderUtils.formParams(addUserForm));
+                .with(MockMvcRequestBuilderUtils.form(addUserForm));
         MockHttpServletRequest request = mockHttpServletRequestBuilder.buildRequest(this.servletContext);
         mockHttpServletRequestBuilder.postProcessRequest(request);
 
@@ -179,7 +179,7 @@ public class MockMvcRequestBuilderUtilsTests {
                 .identificationNumber(BigDecimal.TEN)
                 .build();
         MockHttpServletRequestBuilder mockHttpServletRequestBuilder = post(POST_FORM_URL)
-                .with(MockMvcRequestBuilderUtils.formParams(addUserForm));
+                .with(MockMvcRequestBuilderUtils.form(addUserForm));
         MockHttpServletRequest request = mockHttpServletRequestBuilder.buildRequest(this.servletContext);
         mockHttpServletRequestBuilder.postProcessRequest(request);
 
@@ -192,7 +192,7 @@ public class MockMvcRequestBuilderUtilsTests {
                 .identificationNumberBigInt(BigInteger.TEN)
                 .build();
         MockHttpServletRequestBuilder mockHttpServletRequestBuilder = post(POST_FORM_URL)
-                .with(MockMvcRequestBuilderUtils.formParams(addUserForm));
+                .with(MockMvcRequestBuilderUtils.form(addUserForm));
         MockHttpServletRequest request = mockHttpServletRequestBuilder.buildRequest(this.servletContext);
         mockHttpServletRequestBuilder.postProcessRequest(request);
 
@@ -212,7 +212,7 @@ public class MockMvcRequestBuilderUtilsTests {
 
             final AddUserForm build = AddUserForm.builder().identificationNumberBigInt(BigInteger.TEN).build();
             MockHttpServletRequestBuilder mockHttpServletRequestBuilder = post(POST_FORM_URL)
-                    .with(MockMvcRequestBuilderUtils.formParams(build));
+                    .with(MockMvcRequestBuilderUtils.form(build));
             MockHttpServletRequest request = mockHttpServletRequestBuilder.buildRequest(this.servletContext);
             mockHttpServletRequestBuilder.postProcessRequest(request);
             

--- a/src/test/java/io/florianlopes/spring/test/web/servlet/request/MockMvcRequestBuilderUtilsTests.java
+++ b/src/test/java/io/florianlopes/spring/test/web/servlet/request/MockMvcRequestBuilderUtilsTests.java
@@ -12,6 +12,8 @@ import javax.servlet.ServletContext;
 import org.apache.commons.lang3.StringUtils;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.beans.propertyeditors.CustomNumberEditor;
@@ -32,6 +34,193 @@ public class MockMvcRequestBuilderUtilsTests {
     @Before
     public void setUp() {
         this.servletContext = new MockServletContext();
+    }
+    
+    @Test
+    public void withParamsNullForm() {
+        MockHttpServletRequestBuilder mockHttpServletRequestBuilder = post(POST_FORM_URL)
+                .with(MockMvcRequestBuilderUtils.formParams(null));
+        final MockHttpServletRequest request = mockHttpServletRequestBuilder.buildRequest(this.servletContext);
+        mockHttpServletRequestBuilder.postProcessRequest(request);
+
+        assertEquals(0, request.getParameterMap().size());
+    }
+
+    @Test
+    public void withParamsNullAndEmptyFields() {
+        MockHttpServletRequestBuilder mockHttpServletRequestBuilder = post(POST_FORM_URL)
+                .with(MockMvcRequestBuilderUtils.formParams(new AddUserForm("", "", null, null)));
+        final MockHttpServletRequest request = mockHttpServletRequestBuilder.buildRequest(this.servletContext);
+        mockHttpServletRequestBuilder.postProcessRequest(request);
+
+        assertEquals(StringUtils.EMPTY, request.getParameter("name"));
+        assertEquals(StringUtils.EMPTY, request.getParameter("firstName"));
+        assertNull(request.getParameter("birthDate"));
+        assertNull(request.getParameter("currentAddress.city"));
+    }
+
+    @Test
+    public void withParamsSimpleFields() {
+        final AddUserForm addUserForm = AddUserForm.builder()
+                .firstName("John").name("Doe")
+                .currentAddress(new AddUserForm.Address(1, "Street", 5222, "New York"))
+                .build();
+        
+        MockHttpServletRequestBuilder mockHttpServletRequestBuilder = post(POST_FORM_URL)
+                .with(MockMvcRequestBuilderUtils.formParams(addUserForm));
+        final MockHttpServletRequest request = mockHttpServletRequestBuilder.buildRequest(this.servletContext);
+        mockHttpServletRequestBuilder.postProcessRequest(request);
+
+        assertEquals("John", request.getParameter("firstName"));
+        assertEquals("New York", request.getParameter("currentAddress.city"));
+    }
+
+    @Test
+    public void withParamsSimpleCollection() {
+        final AddUserForm addUserForm = AddUserForm.builder().firstName("John").name("Doe")
+                .usernames(Arrays.asList("john.doe", "jdoe"))
+                .build();
+        
+        MockHttpServletRequestBuilder mockHttpServletRequestBuilder = post(POST_FORM_URL)
+                .with(MockMvcRequestBuilderUtils.formParams(addUserForm));
+        final MockHttpServletRequest request = mockHttpServletRequestBuilder.buildRequest(this.servletContext);
+        mockHttpServletRequestBuilder.postProcessRequest(request);
+
+        assertEquals("john.doe", request.getParameter("usernames[0]"));
+        assertEquals("jdoe", request.getParameter("usernames[1]"));
+    }
+
+    @Test
+    public void withParamsComplextCollection() {
+        final AddUserForm addUserForm = AddUserForm.builder().firstName("John").name("Doe").build();
+        MockMvcRequestBuilderUtils.registerPropertyEditor(LocalDate.class, new CustomLocalDatePropertyEditor(DATE_FORMAT_PATTERN));
+        final LocalDate bachelorDate = LocalDate.now().minusYears(2);
+        final LocalDate masterDate = LocalDate.now();
+        addUserForm.setDiplomas(Arrays.asList(new AddUserForm.Diploma("License", bachelorDate), new AddUserForm.Diploma("MSC", masterDate)));
+     
+        MockHttpServletRequestBuilder mockHttpServletRequestBuilder = post(POST_FORM_URL)
+                .with(MockMvcRequestBuilderUtils.formParams(addUserForm));
+        MockHttpServletRequest request = mockHttpServletRequestBuilder.buildRequest(this.servletContext);
+        mockHttpServletRequestBuilder.postProcessRequest(request);
+        
+        assertEquals("License", request.getParameter("diplomas[0].name"));
+        assertEquals(bachelorDate.format(DateTimeFormatter.ofPattern(DATE_FORMAT_PATTERN)), request.getParameter("diplomas[0].date"));
+        assertEquals("MSC", request.getParameter("diplomas[1].name"));
+        assertEquals(masterDate.format(DateTimeFormatter.ofPattern(DATE_FORMAT_PATTERN)), request.getParameter("diplomas[1].date"));
+    }
+    
+    @Test
+    public void withParamsSimpleArray() {
+        final AddUserForm addUserForm = AddUserForm.builder().firstName("John").name("Doe")
+                .usernamesArray(new String[]{"john.doe", "jdoe"})
+                .build();
+        MockHttpServletRequestBuilder mockHttpServletRequestBuilder = post(POST_FORM_URL)
+                .with(MockMvcRequestBuilderUtils.formParams(addUserForm));
+        MockHttpServletRequest request = mockHttpServletRequestBuilder.buildRequest(this.servletContext);
+        mockHttpServletRequestBuilder.postProcessRequest(request);
+
+        assertEquals("john.doe", request.getParameter("usernamesArray[0]"));
+        assertEquals("jdoe", request.getParameter("usernamesArray[1]"));
+    }
+
+    @Test
+    public void withParamsComplexArray() {
+        final AddUserForm addUserForm = AddUserForm.builder().firstName("John").name("Doe")
+                .usernames(Arrays.asList("john.doe", "jdoe"))
+                .formerAddresses(new AddUserForm.Address[]{
+                        new AddUserForm.Address(10, "Street", 5222, "Chicago"),
+                        new AddUserForm.Address(20, "Street", 5222, "Washington")
+                })
+                .build();
+        MockHttpServletRequestBuilder mockHttpServletRequestBuilder = post(POST_FORM_URL)
+                .with(MockMvcRequestBuilderUtils.formParams(addUserForm));
+        MockHttpServletRequest request = mockHttpServletRequestBuilder.buildRequest(this.servletContext);
+        mockHttpServletRequestBuilder.postProcessRequest(request);
+
+        assertEquals("john.doe", request.getParameter("usernames[0]"));
+        assertEquals("jdoe", request.getParameter("usernames[1]"));
+    }
+
+    @Test
+    public void withParamsEnumField() {
+        final AddUserForm addUserForm = AddUserForm.builder()
+                .firstName("John").name("Doe").gender(AddUserForm.Gender.MALE)
+                .build();
+        MockHttpServletRequestBuilder mockHttpServletRequestBuilder = post(POST_FORM_URL)
+                .with(MockMvcRequestBuilderUtils.formParams(addUserForm));
+        MockHttpServletRequest request = mockHttpServletRequestBuilder.buildRequest(this.servletContext);
+        mockHttpServletRequestBuilder.postProcessRequest(request);
+
+        assertEquals("MALE", request.getParameter("gender"));
+    }
+
+    @Test
+    public void withParamsSimpleMapField() {
+        final Map<String, String> metadatas = new HashMap<>();
+        metadatas.put("firstName", "John");
+        metadatas.put("name", "Doe");
+        metadatas.put("gender", null);
+        final AddUserForm addUserForm = AddUserForm.builder()
+                .metadatas(metadatas)
+                .build();
+        MockHttpServletRequestBuilder mockHttpServletRequestBuilder = post(POST_FORM_URL)
+                .with(MockMvcRequestBuilderUtils.formParams(addUserForm));
+        MockHttpServletRequest request = mockHttpServletRequestBuilder.buildRequest(this.servletContext);
+        mockHttpServletRequestBuilder.postProcessRequest(request);
+
+        assertEquals("John", request.getParameter("metadatas[firstName]"));
+        assertEquals("Doe", request.getParameter("metadatas[name]"));
+        assertEquals("", request.getParameter("metadatas[gender]"));
+    }
+
+    @Test
+    public void withParamsBigDecimal() {
+        final AddUserForm addUserForm = AddUserForm.builder()
+                .identificationNumber(BigDecimal.TEN)
+                .build();
+        MockHttpServletRequestBuilder mockHttpServletRequestBuilder = post(POST_FORM_URL)
+                .with(MockMvcRequestBuilderUtils.formParams(addUserForm));
+        MockHttpServletRequest request = mockHttpServletRequestBuilder.buildRequest(this.servletContext);
+        mockHttpServletRequestBuilder.postProcessRequest(request);
+
+        assertEquals("10", request.getParameter("identificationNumber"));
+    }
+
+    @Test
+    public void withParamsBigInteger() {
+        final AddUserForm addUserForm = AddUserForm.builder()
+                .identificationNumberBigInt(BigInteger.TEN)
+                .build();
+        MockHttpServletRequestBuilder mockHttpServletRequestBuilder = post(POST_FORM_URL)
+                .with(MockMvcRequestBuilderUtils.formParams(addUserForm));
+        MockHttpServletRequest request = mockHttpServletRequestBuilder.buildRequest(this.servletContext);
+        mockHttpServletRequestBuilder.postProcessRequest(request);
+
+        assertEquals("10", request.getParameter("identificationNumberBigInt"));
+    }
+
+    @Test
+    public void withParamsRegisterPropertyEditor() {
+        try {
+            // Registering a property editor should override default conversion strategy
+            MockMvcRequestBuilderUtils.registerPropertyEditor(BigInteger.class, new PropertyEditorSupport() {
+                @Override
+                public String getAsText() {
+                    return "textValue";
+                }
+            });
+
+            final AddUserForm build = AddUserForm.builder().identificationNumberBigInt(BigInteger.TEN).build();
+            MockHttpServletRequestBuilder mockHttpServletRequestBuilder = post(POST_FORM_URL)
+                    .with(MockMvcRequestBuilderUtils.formParams(build));
+            MockHttpServletRequest request = mockHttpServletRequestBuilder.buildRequest(this.servletContext);
+            mockHttpServletRequestBuilder.postProcessRequest(request);
+            
+            assertEquals("textValue", request.getParameter("identificationNumberBigInt"));
+        } finally {
+            // Restore original property editor
+            MockMvcRequestBuilderUtils.registerPropertyEditor(BigInteger.class, new CustomNumberEditor(BigInteger.class, true));
+        }
     }
 
     @Test


### PR DESCRIPTION
Add support for adding form params via MockHttpServletRequestBuilder#with(RequestPostProcessor).

For use cases where you don't want to use either POST/PUT, the form content type and a fixed URL.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/f-lopes/spring-mvc-test-utils/9)
<!-- Reviewable:end -->
