### PR TITLE
Travis CI: compile against multiple openjdk8/9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,4 @@
 language: java
+jdk:
+  - openjdk8
+  - openjdk9


### PR DESCRIPTION
Compile against multiple JDK in Travis CI
- openjdk8
- openjdk9

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/f-lopes/spring-mvc-test-utils/16)
<!-- Reviewable:end -->
