### PR TITLE
Add configuration class to exclude specific fields

### DIFF
--- a/src/main/java/io/florianlopes/spring/test/web/servlet/request/MockMvcRequestBuilderUtils.java
+++ b/src/main/java/io/florianlopes/spring/test/web/servlet/request/MockMvcRequestBuilderUtils.java
@@ -40,7 +40,11 @@ import org.springframework.util.CollectionUtils;
 public class MockMvcRequestBuilderUtils {
 
     private static final PropertyEditorRegistrySupport PROPERTY_EDITOR_REGISTRY = new SimpleTypeConverter();
-    private static final Configuration DEFAULT_CONFIG = Configuration.builder().build();
+    private static final Configuration DEFAULT_CONFIG = Configuration.builder()
+            .includeFinal(true)
+            .includeTransient(false)
+            .includeStatic(false)
+            .build();
 
     private static final Logger LOGGER = LoggerFactory.getLogger(MockMvcRequestBuilderUtils.class);
 
@@ -308,10 +312,7 @@ public class MockMvcRequestBuilderUtils {
          * Creates a new builder that excludes transient and static fields by default.
          */
         public static Builder builder() {
-            return new Builder()
-                    .includeFinal(true)
-                    .includeTransient(false)
-                    .includeStatic(false);
+            return new Builder();
         }
 
         public static class Builder {
@@ -347,21 +348,15 @@ public class MockMvcRequestBuilderUtils {
                 Predicate<Field> fieldPredicate = this.fieldPredicate != null ? BASE_PREDICATE.and(this.fieldPredicate) : BASE_PREDICATE;
 
                 if (!this.includeFinal) {
-                    fieldPredicate = fieldPredicate != null
-                            ? fieldPredicate.and(Builder::isNotFinal)
-                            : Builder::isNotFinal;
+                    fieldPredicate = fieldPredicate.and(Builder::isNotFinal);
                 }
 
                 if (!this.includeTransient) {
-                    fieldPredicate = fieldPredicate != null
-                            ? fieldPredicate.and(Builder::isNotTransient)
-                            : Builder::isNotTransient;
+                    fieldPredicate = fieldPredicate.and(Builder::isNotTransient);
                 }
 
                 if (!this.includeStatic) {
-                    fieldPredicate = fieldPredicate != null
-                            ? fieldPredicate.and(Builder::isNotStatic)
-                            : Builder::isNotStatic;
+                    fieldPredicate = fieldPredicate.and(Builder::isNotStatic);
                 }
 
                 return new Configuration(fieldPredicate);

--- a/src/test/java/io/florianlopes/spring/test/web/servlet/request/ConfigurationForm.java
+++ b/src/test/java/io/florianlopes/spring/test/web/servlet/request/ConfigurationForm.java
@@ -11,8 +11,8 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class ConfigurationForm {
 
-    public static final Comparator<ConfigurationForm> COMPARATOR_NAME = Comparator.comparing(ConfigurationForm::getName);
-    public static String STATIC_NAME = "static name";
+    private static final Comparator<ConfigurationForm> COMPARATOR_NAME = Comparator.comparing(ConfigurationForm::getName);
+    private static String STATIC_NAME = "static name";
 
     private String name;
     private transient String transientName;

--- a/src/test/java/io/florianlopes/spring/test/web/servlet/request/ConfigurationForm.java
+++ b/src/test/java/io/florianlopes/spring/test/web/servlet/request/ConfigurationForm.java
@@ -12,12 +12,12 @@ import lombok.NoArgsConstructor;
 public class ConfigurationForm {
 
     public static final Comparator<ConfigurationForm> COMPARATOR_NAME = Comparator.comparing(ConfigurationForm::getName);
-    public static final String STATIC_NAME = "static name";
+    public static String STATIC_NAME = "static name";
 
     private String name;
     private transient String transientName;
     private final String finalName = "finalValue";
-    
+
     private Inner inner;
 
     @Data

--- a/src/test/java/io/florianlopes/spring/test/web/servlet/request/ConfigurationForm.java
+++ b/src/test/java/io/florianlopes/spring/test/web/servlet/request/ConfigurationForm.java
@@ -1,0 +1,29 @@
+package io.florianlopes.spring.test.web.servlet.request;
+
+import java.util.Comparator;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class ConfigurationForm {
+
+    public static final Comparator<ConfigurationForm> COMPARATOR_NAME = Comparator.comparing(ConfigurationForm::getName);
+    public static final String STATIC_NAME = "static name";
+
+    private String name;
+    private transient String transientName;
+    private final String finalName = "finalValue";
+    
+    private Inner inner;
+
+    @Data
+    @AllArgsConstructor
+    public class Inner {
+        private String value;
+    }
+
+}

--- a/src/test/java/io/florianlopes/spring/test/web/servlet/request/MockMvcRequestBuilderUtilsTests.java
+++ b/src/test/java/io/florianlopes/spring/test/web/servlet/request/MockMvcRequestBuilderUtilsTests.java
@@ -1,5 +1,10 @@
 package io.florianlopes.spring.test.web.servlet.request;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+
 import java.beans.PropertyEditorSupport;
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -8,17 +13,19 @@ import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
+
 import javax.servlet.ServletContext;
+
 import org.apache.commons.lang3.StringUtils;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.propertyeditors.CustomNumberEditor;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockServletContext;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+
+import io.florianlopes.spring.test.web.servlet.request.MockMvcRequestBuilderUtils.Configuration;
 
 /**
  * @author Florian Lopes
@@ -28,13 +35,16 @@ public class MockMvcRequestBuilderUtilsTests {
     private static final String POST_FORM_URL = "/test";
     private static final String DATE_FORMAT_PATTERN = "dd/MM/yyyy";
 
+    private static final Configuration EXCLUDE_STATIC_TRANSIENT_SYNTHETIC = Configuration.builder().includeTransient(false).build();
+    private static final Configuration INCLUDE_TRANSIENT = Configuration.builder().includeTransient(true).build();
+
     private ServletContext servletContext;
 
     @BeforeEach
     public void setUp() {
         this.servletContext = new MockServletContext();
     }
-    
+
     @Test
     public void withParamsNullForm() {
         MockHttpServletRequestBuilder mockHttpServletRequestBuilder = post(POST_FORM_URL)
@@ -64,7 +74,7 @@ public class MockMvcRequestBuilderUtilsTests {
                 .firstName("John").name("Doe")
                 .currentAddress(new AddUserForm.Address(1, "Street", 5222, "New York"))
                 .build();
-        
+
         MockHttpServletRequestBuilder mockHttpServletRequestBuilder = post(POST_FORM_URL)
                 .with(MockMvcRequestBuilderUtils.form(addUserForm));
         final MockHttpServletRequest request = mockHttpServletRequestBuilder.buildRequest(this.servletContext);
@@ -79,7 +89,7 @@ public class MockMvcRequestBuilderUtilsTests {
         final AddUserForm addUserForm = AddUserForm.builder().firstName("John").name("Doe")
                 .usernames(Arrays.asList("john.doe", "jdoe"))
                 .build();
-        
+
         MockHttpServletRequestBuilder mockHttpServletRequestBuilder = post(POST_FORM_URL)
                 .with(MockMvcRequestBuilderUtils.form(addUserForm));
         final MockHttpServletRequest request = mockHttpServletRequestBuilder.buildRequest(this.servletContext);
@@ -96,22 +106,22 @@ public class MockMvcRequestBuilderUtilsTests {
         final LocalDate bachelorDate = LocalDate.now().minusYears(2);
         final LocalDate masterDate = LocalDate.now();
         addUserForm.setDiplomas(Arrays.asList(new AddUserForm.Diploma("License", bachelorDate), new AddUserForm.Diploma("MSC", masterDate)));
-     
+
         MockHttpServletRequestBuilder mockHttpServletRequestBuilder = post(POST_FORM_URL)
                 .with(MockMvcRequestBuilderUtils.form(addUserForm));
         MockHttpServletRequest request = mockHttpServletRequestBuilder.buildRequest(this.servletContext);
         mockHttpServletRequestBuilder.postProcessRequest(request);
-        
+
         assertEquals("License", request.getParameter("diplomas[0].name"));
         assertEquals(bachelorDate.format(DateTimeFormatter.ofPattern(DATE_FORMAT_PATTERN)), request.getParameter("diplomas[0].date"));
         assertEquals("MSC", request.getParameter("diplomas[1].name"));
         assertEquals(masterDate.format(DateTimeFormatter.ofPattern(DATE_FORMAT_PATTERN)), request.getParameter("diplomas[1].date"));
     }
-    
+
     @Test
     public void withParamsSimpleArray() {
         final AddUserForm addUserForm = AddUserForm.builder().firstName("John").name("Doe")
-                .usernamesArray(new String[]{"john.doe", "jdoe"})
+                .usernamesArray(new String[] { "john.doe", "jdoe" })
                 .build();
         MockHttpServletRequestBuilder mockHttpServletRequestBuilder = post(POST_FORM_URL)
                 .with(MockMvcRequestBuilderUtils.form(addUserForm));
@@ -126,7 +136,7 @@ public class MockMvcRequestBuilderUtilsTests {
     public void withParamsComplexArray() {
         final AddUserForm addUserForm = AddUserForm.builder().firstName("John").name("Doe")
                 .usernames(Arrays.asList("john.doe", "jdoe"))
-                .formerAddresses(new AddUserForm.Address[]{
+                .formerAddresses(new AddUserForm.Address[] {
                         new AddUserForm.Address(10, "Street", 5222, "Chicago"),
                         new AddUserForm.Address(20, "Street", 5222, "Washington")
                 })
@@ -214,7 +224,7 @@ public class MockMvcRequestBuilderUtilsTests {
                     .with(MockMvcRequestBuilderUtils.form(build));
             MockHttpServletRequest request = mockHttpServletRequestBuilder.buildRequest(this.servletContext);
             mockHttpServletRequestBuilder.postProcessRequest(request);
-            
+
             assertEquals("textValue", request.getParameter("identificationNumberBigInt"));
         } finally {
             // Restore original property editor
@@ -295,7 +305,7 @@ public class MockMvcRequestBuilderUtilsTests {
     @Test
     public void simpleArray() {
         final AddUserForm addUserForm = AddUserForm.builder().firstName("John").name("Doe")
-                .usernamesArray(new String[]{"john.doe", "jdoe"})
+                .usernamesArray(new String[] { "john.doe", "jdoe" })
                 .build();
         final MockHttpServletRequestBuilder mockHttpServletRequestBuilder = MockMvcRequestBuilderUtils.postForm(POST_FORM_URL, addUserForm);
         final MockHttpServletRequest request = mockHttpServletRequestBuilder.buildRequest(this.servletContext);
@@ -308,7 +318,7 @@ public class MockMvcRequestBuilderUtilsTests {
     public void complexArray() {
         final AddUserForm addUserForm = AddUserForm.builder().firstName("John").name("Doe")
                 .usernames(Arrays.asList("john.doe", "jdoe"))
-                .formerAddresses(new AddUserForm.Address[]{
+                .formerAddresses(new AddUserForm.Address[] {
                         new AddUserForm.Address(10, "Street", 5222, "Chicago"),
                         new AddUserForm.Address(20, "Street", 5222, "Washington")
                 })
@@ -409,4 +419,91 @@ public class MockMvcRequestBuilderUtilsTests {
 
         assertEquals("PUT", request.getMethod());
     }
+
+    @Test
+    public void testSyntheticFieldExcluded() {
+        final ConfigurationForm form = new ConfigurationForm();
+        form.setInner(form.new Inner("inner"));
+
+        final MockHttpServletRequestBuilder mockHttpServletRequestBuilder = MockMvcRequestBuilderUtils.postForm(POST_FORM_URL, form, EXCLUDE_STATIC_TRANSIENT_SYNTHETIC);
+        final MockHttpServletRequest request = mockHttpServletRequestBuilder.buildRequest(servletContext);
+
+        assertEquals(1, request.getParameterMap().size());
+        assertEquals("inner", request.getParameter("inner.value"));
+    }
+
+    @Nested
+    class ConfigurationTest {
+
+        @Test
+        public void testDefaultConfig() {
+            final ConfigurationForm form = new ConfigurationForm();
+            form.setName("name");
+            form.setTransientName("transientName");
+            form.setInner(form.new Inner("inner"));
+
+            final MockHttpServletRequestBuilder mockHttpServletRequestBuilder = MockMvcRequestBuilderUtils.postForm(POST_FORM_URL, form);
+            final MockHttpServletRequest request = mockHttpServletRequestBuilder.buildRequest(servletContext);
+
+            assertEquals(2, request.getParameterMap().size());
+            assertEquals("name", request.getParameter("name"));
+            assertEquals("inner", request.getParameter("inner.value"));
+        }
+
+        @Test
+        public void testExcludeStaticTransientFields() {
+            final ConfigurationForm form = new ConfigurationForm();
+            form.setTransientName("transientName");
+
+            final MockHttpServletRequestBuilder mockHttpServletRequestBuilder = MockMvcRequestBuilderUtils.postForm(POST_FORM_URL, form, EXCLUDE_STATIC_TRANSIENT_SYNTHETIC);
+            final MockHttpServletRequest request = mockHttpServletRequestBuilder.buildRequest(servletContext);
+
+            assertTrue(request.getParameterMap().isEmpty());
+        }
+
+        @Test
+        public void testIncludeTransientField() {
+            final ConfigurationForm form = new ConfigurationForm();
+            form.setName("name");
+            form.setTransientName("transientName");
+
+            final MockHttpServletRequestBuilder mockHttpServletRequestBuilder = MockMvcRequestBuilderUtils.postForm(POST_FORM_URL, form, INCLUDE_TRANSIENT);
+            final MockHttpServletRequest request = mockHttpServletRequestBuilder.buildRequest(servletContext);
+
+            assertEquals(2, request.getParameterMap().size());
+            assertEquals("name", request.getParameter("name"));
+            assertEquals("transientName", request.getParameter("transientName"));
+        }
+
+        @Test
+        public void testCustomPredicate() {
+            final Configuration config = Configuration.builder().fieldPredicate(field -> "transientName".equals(field.getName())).build();
+
+            final ConfigurationForm form = new ConfigurationForm();
+            form.setName("name");
+            form.setTransientName("transientName");
+
+            final MockHttpServletRequestBuilder mockHttpServletRequestBuilder = MockMvcRequestBuilderUtils.postForm(POST_FORM_URL, form, config);
+            final MockHttpServletRequest request = mockHttpServletRequestBuilder.buildRequest(servletContext);
+
+            assertTrue(request.getParameterMap().isEmpty());
+        }
+
+        @Test
+        public void testCustomPredicateWithModifier() {
+            final Configuration config = Configuration.builder().includeTransient(true).fieldPredicate(field -> "transientName".equals(field.getName())).build();
+
+            final ConfigurationForm form = new ConfigurationForm();
+            form.setName("name");
+            form.setTransientName("transientName");
+
+            final MockHttpServletRequestBuilder mockHttpServletRequestBuilder = MockMvcRequestBuilderUtils.postForm(POST_FORM_URL, form, config);
+            final MockHttpServletRequest request = mockHttpServletRequestBuilder.buildRequest(servletContext);
+
+            assertEquals(1, request.getParameterMap().size());
+            assertEquals("transientName", request.getParameter("transientName"));
+        }
+
+    }
+
 }


### PR DESCRIPTION
This PR adds a configuration class to exclude fields based on a predicate. In addition static and final fields will always be excluded and transient fields will be excluded by default.

See initial discussion in #175. 

Resolves #175

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/f-lopes/spring-mvc-test-utils/177)
<!-- Reviewable:end -->
