### PR TITLE
feat(ci): integrate SonarCloud analysis into build process

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,6 +33,13 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-
 
+      - name: Cache SonarCloud packages
+        uses: actions/cache@v3
+        with:
+          path: ~/.sonar/cache
+          key: ${{ runner.os }}-sonar
+          restore-keys: ${{ runner.os }}-sonar
+
       - name: Retrieve current version
         id: current_version
         run: echo "project_version=$(mvn help:evaluate -Dexpression=project.version -Dchangelist= -q -DforceStdout)" >> "$GITHUB_OUTPUT"
@@ -42,7 +49,10 @@ jobs:
         run: echo "candidate_version_revision=${{ steps.current_version.outputs.project_version }}.$GITHUB_RUN_ID" >> "$GITHUB_OUTPUT"
 
       - name: Build candidate version
-        run: mvn -B -pl '!smoke-tests' clean install -Drevision=${{ steps.candidate_version.outputs.candidate_version_revision }} -Dchangelist=-rc
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: mvn -B -pl '!smoke-tests' clean install -Drevision=${{ steps.candidate_version.outputs.candidate_version_revision }} -Dchangelist=-rc org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=f-lopes_spring-mvc-test-utils
 
       - name: Upload JaCoCo coverage reports to Codecov
         uses: codecov/codecov-action@v4.5.0

--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,9 @@
 		<versions-maven-plugin.version>2.17.1</versions-maven-plugin.version>
 		<maven-pmd-plugin.version>3.25.0</maven-pmd-plugin.version>
 		<spotbugs-maven-plugin.version>4.8.6.2</spotbugs-maven-plugin.version>
+
+		<sonar.organization>f-lopes</sonar.organization>
+		<sonar.host.url>https://sonarcloud.io</sonar.host.url>
 	</properties>
 
 	<dependencyManagement>


### PR DESCRIPTION
Integrate SonarCloud analysis into build process

- Add SonarCloud configuration to `pom.xml` for project analysis
- Update GitHub Actions workflow to include SonarCloud analysis steps