### PR TITLE
refactor: MockMvcRequestBuilderUtils and its Configuration

### DIFF
--- a/smoke-tests/pom.xml
+++ b/smoke-tests/pom.xml
@@ -57,6 +57,11 @@
             <version>${hibernate-validator.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>1.5.8</version>
+        </dependency>
 
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/smoke-tests/src/test/java/io/florianlopes/spring/test/web/servlet/request/MockMvcRequestBuilderUtilsSmokeTests.java
+++ b/smoke-tests/src/test/java/io/florianlopes/spring/test/web/servlet/request/MockMvcRequestBuilderUtilsSmokeTests.java
@@ -41,7 +41,7 @@ public class MockMvcRequestBuilderUtilsSmokeTests {
 
     @Test
     public void fullTestPostMethod() throws Exception {
-        final AddUserForm addUserForm = aCompletedAddUserForm();
+        final AddUserForm addUserForm = aCompleteAddUserForm();
 
         final Configuration config = Configuration.builder()
                 .withPropertyEditor(new CustomLocalDatePropertyEditor(DATE_FORMAT_PATTERN), LocalDate.class)
@@ -52,7 +52,7 @@ public class MockMvcRequestBuilderUtilsSmokeTests {
 
     @Test
     public void fullTestPutMethod() throws Exception {
-        final AddUserForm addUserForm = aCompletedAddUserForm();
+        final AddUserForm addUserForm = aCompleteAddUserForm();
 
         final Configuration config = Configuration.builder()
                 .withPropertyEditor(new CustomLocalDatePropertyEditor(DATE_FORMAT_PATTERN), LocalDate.class)
@@ -61,7 +61,7 @@ public class MockMvcRequestBuilderUtilsSmokeTests {
                 .andExpect(MockMvcResultMatchers.model().hasNoErrors());
     }
 
-    private AddUserForm aCompletedAddUserForm() {
+    private AddUserForm aCompleteAddUserForm() {
         final List<String> usernames = List.of("john.doe", "jdoe");
         return AddUserForm.builder()
                 .firstName("John").name("Doe")
@@ -107,7 +107,7 @@ public class MockMvcRequestBuilderUtilsSmokeTests {
 
         @Test
         public void withParamsFullTestGetMethod() throws Exception {
-            final AddUserForm addUserForm = aCompletedAddUserForm();
+            final AddUserForm addUserForm = aCompleteAddUserForm();
 
             mockMvc.perform(get(USERS_ENDPOINT).with(MockMvcRequestBuilderUtils.form(addUserForm)))
                     .andExpect(MockMvcResultMatchers.model().hasNoErrors());
@@ -115,7 +115,7 @@ public class MockMvcRequestBuilderUtilsSmokeTests {
 
         @Test
         public void withParamsFullTestPutMethod() throws Exception {
-            final AddUserForm addUserForm = aCompletedAddUserForm();
+            final AddUserForm addUserForm = aCompleteAddUserForm();
 
             mockMvc.perform(put(USERS_ENDPOINT).with(MockMvcRequestBuilderUtils.form(addUserForm)))
                     .andExpect(MockMvcResultMatchers.model().hasNoErrors());
@@ -123,7 +123,7 @@ public class MockMvcRequestBuilderUtilsSmokeTests {
 
         @Test
         public void withParamsFullTestPostMethod() throws Exception {
-            final AddUserForm addUserForm = aCompletedAddUserForm();
+            final AddUserForm addUserForm = aCompleteAddUserForm();
 
             mockMvc.perform(post(USERS_ENDPOINT).with(MockMvcRequestBuilderUtils.form(addUserForm)))
                     .andExpect(MockMvcResultMatchers.model().hasNoErrors());

--- a/smoke-tests/src/test/java/io/florianlopes/spring/test/web/servlet/request/MockMvcRequestBuilderUtilsSmokeTests.java
+++ b/smoke-tests/src/test/java/io/florianlopes/spring/test/web/servlet/request/MockMvcRequestBuilderUtilsSmokeTests.java
@@ -3,6 +3,7 @@ package io.florianlopes.spring.test.web.servlet.request;
 import jakarta.validation.Valid;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.stereotype.Controller;
 import org.springframework.test.web.servlet.MockMvc;
@@ -25,7 +26,9 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
  */
 public class MockMvcRequestBuilderUtilsSmokeTests {
 
-    private static final String DATE_FORMAT_PATTERN = "dd/MM/yyyy";
+    private static final String DATE_FORMAT_PATTERN = "dd.MM.yyyy";
+
+    private static final String USERS_ENDPOINT = "/users";
 
     private MockMvc mockMvc;
 
@@ -34,65 +37,58 @@ public class MockMvcRequestBuilderUtilsSmokeTests {
         this.mockMvc = MockMvcBuilders.standaloneSetup(new UserController())
                 .setValidator(new LocalValidatorFactoryBean())
                 .build();
-
-        MockMvcRequestBuilderUtils.registerPropertyEditor(LocalDate.class, new CustomLocalDatePropertyEditor(DATE_FORMAT_PATTERN));
     }
 
     @Test
-    public void fullTest() throws Exception {
-        final AddUserForm addUserForm = getCompletedAddUserForm();
+    public void fullTestPostMethod() throws Exception {
+        final AddUserForm addUserForm = aCompletedAddUserForm();
 
-        this.mockMvc.perform(MockMvcRequestBuilderUtils.postForm("/users", addUserForm))
+        final Configuration config = Configuration.builder()
+                .withPropertyEditor(new CustomLocalDatePropertyEditor(DATE_FORMAT_PATTERN), LocalDate.class)
+                .build();
+        this.mockMvc.perform(MockMvcRequestBuilderUtils.postForm(USERS_ENDPOINT, addUserForm, config))
                 .andExpect(MockMvcResultMatchers.model().hasNoErrors());
     }
 
     @Test
-    public void withParamsFullTestGetMethod() throws Exception {
-        final AddUserForm addUserForm = getCompletedAddUserForm();
+    public void fullTestPutMethod() throws Exception {
+        final AddUserForm addUserForm = aCompletedAddUserForm();
 
-        this.mockMvc.perform(get("/users").with(MockMvcRequestBuilderUtils.form(addUserForm)))
+        final Configuration config = Configuration.builder()
+                .withPropertyEditor(new CustomLocalDatePropertyEditor(DATE_FORMAT_PATTERN), LocalDate.class)
+                .build();
+        this.mockMvc.perform(MockMvcRequestBuilderUtils.putForm(USERS_ENDPOINT, addUserForm, config))
                 .andExpect(MockMvcResultMatchers.model().hasNoErrors());
     }
 
-    @Test
-    public void withParamsFullTestPutMethod() throws Exception {
-        final AddUserForm addUserForm = getCompletedAddUserForm();
-
-        this.mockMvc.perform(put("/users").with(MockMvcRequestBuilderUtils.form(addUserForm)))
-                .andExpect(MockMvcResultMatchers.model().hasNoErrors());
-    }
-
-    @Test
-    public void withParamsFullTestPostMethod() throws Exception {
-        final AddUserForm addUserForm = getCompletedAddUserForm();
-
-        this.mockMvc.perform(post("/users").with(MockMvcRequestBuilderUtils.form(addUserForm)))
-                .andExpect(MockMvcResultMatchers.model().hasNoErrors());
-    }
-
-    private AddUserForm getCompletedAddUserForm() {
-        final LocalDate userBirthDate = LocalDate.of(2016, 8, 29);
-        final LocalDate bachelorDate = LocalDate.now().minusYears(2);
-        final LocalDate masterDate = LocalDate.now();
-        final List<AddUserForm.Diploma> userDiplomas = List.of(
-                new AddUserForm.Diploma("License", bachelorDate),
-                new AddUserForm.Diploma("MSC", masterDate)
-        );
-
+    private AddUserForm aCompletedAddUserForm() {
+        final List<String> usernames = List.of("john.doe", "jdoe");
         return AddUserForm.builder()
                 .firstName("John").name("Doe")
-                .usernames(List.of("john.doe", "jdoe"))
-                .usernamesArray(new String[]{"john.doe", "jdoe"})
+                .usernames(usernames)
+                .usernamesArray(usernames.toArray(new String[0]))
                 .gender(AddUserForm.Gender.MALE)
                 .identificationNumber(BigDecimal.ONE)
                 .identificationNumberBigInt(BigInteger.ONE)
-                .currentAddress(new AddUserForm.Address(1, "Street", 5222, "New York"))
+                .currentAddress(
+                        new AddUserForm.Address(1, "Street", 5222, "New York")
+                                .withLinkedAddress(
+                                        new AddUserForm.Address(2, "Linked Street", 60, "New York")
+                                )
+                )
                 .formerAddresses(new AddUserForm.Address[]{
-                        new AddUserForm.Address(10, "Street", 5222, "Chicago"),
-                        new AddUserForm.Address(20, "Street", 5222, "Washington")
+                        new AddUserForm.Address(10, "Chicago Street", 5222, "Chicago"),
+                        new AddUserForm.Address(20, "Washington Street", 6222, "Washington")
                 })
-                .birthDate(userBirthDate)
-                .diplomas(userDiplomas)
+                .birthDate(LocalDate.of(2016, 8, 29))
+                .diplomas(List.of(
+                        new AddUserForm.Diploma("License", LocalDate.now().minusYears(2)),
+                        new AddUserForm.Diploma("MSC", LocalDate.now())
+                ))
+                .diplomasMap(Map.of(
+                        "License", new AddUserForm.Diploma("License", LocalDate.now().minusYears(2)),
+                        "MSC", new AddUserForm.Diploma("MSC", LocalDate.now())
+                ))
                 .metadatas(Map.of("firstName", "John", "name", "Doe"))
                 .build();
     }
@@ -100,9 +96,37 @@ public class MockMvcRequestBuilderUtilsSmokeTests {
     @Controller
     private static class UserController {
 
-        @RequestMapping(value = "/users")
+        @RequestMapping(value = USERS_ENDPOINT)
         public String addUser(@Valid AddUserForm addUserForm, BindingResult bindingResult) {
             return StringUtils.EMPTY;
+        }
+    }
+
+    @Nested
+    class PostProcessorTests {
+
+        @Test
+        public void withParamsFullTestGetMethod() throws Exception {
+            final AddUserForm addUserForm = aCompletedAddUserForm();
+
+            mockMvc.perform(get(USERS_ENDPOINT).with(MockMvcRequestBuilderUtils.form(addUserForm)))
+                    .andExpect(MockMvcResultMatchers.model().hasNoErrors());
+        }
+
+        @Test
+        public void withParamsFullTestPutMethod() throws Exception {
+            final AddUserForm addUserForm = aCompletedAddUserForm();
+
+            mockMvc.perform(put(USERS_ENDPOINT).with(MockMvcRequestBuilderUtils.form(addUserForm)))
+                    .andExpect(MockMvcResultMatchers.model().hasNoErrors());
+        }
+
+        @Test
+        public void withParamsFullTestPostMethod() throws Exception {
+            final AddUserForm addUserForm = aCompletedAddUserForm();
+
+            mockMvc.perform(post(USERS_ENDPOINT).with(MockMvcRequestBuilderUtils.form(addUserForm)))
+                    .andExpect(MockMvcResultMatchers.model().hasNoErrors());
         }
     }
 }

--- a/smoke-tests/src/test/resources/logback.xml
+++ b/smoke-tests/src/test/resources/logback.xml
@@ -1,5 +1,7 @@
 <configuration>
 
+    <statusListener class="ch.qos.logback.core.status.NopStatusListener"/>
+
     <root level="ERROR">
         <appender-ref ref="CONSOLE"/>
     </root>

--- a/spring-mvc-test-utils/pom.xml
+++ b/spring-mvc-test-utils/pom.xml
@@ -21,9 +21,10 @@
         <commons-lang3.version>3.17.0</commons-lang3.version>
         <logback-classic.version>1.5.8</logback-classic.version>
         <hibernate-validator.version>6.1.5.Final</hibernate-validator.version>
-        <slf4j-api.version>1.7.36</slf4j-api.version>
+        <slf4j-api.version>2.0.16</slf4j-api.version>
 
         <assertj-core.version>3.26.3</assertj-core.version>
+        <logcaptor.version>2.9.3</logcaptor.version>
 
         <lombok.version>1.18.34</lombok.version>
 
@@ -119,6 +120,12 @@
             <groupId>org.glassfish</groupId>
             <artifactId>jakarta.el</artifactId>
             <version>${jakarta.el.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.github.hakky54</groupId>
+            <artifactId>logcaptor</artifactId>
+            <version>${logcaptor.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/spring-mvc-test-utils/src/main/java/io/florianlopes/spring/test/web/servlet/request/Configuration.java
+++ b/spring-mvc-test-utils/src/main/java/io/florianlopes/spring/test/web/servlet/request/Configuration.java
@@ -1,12 +1,18 @@
 package io.florianlopes.spring.test.web.servlet.request;
 
+import org.springframework.beans.PropertyEditorRegistrySupport;
+
+import java.beans.PropertyEditor;
+import java.beans.PropertyEditorSupport;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.util.Objects;
 import java.util.function.Predicate;
 
 /**
- * Configuration class that allows the exclusion of specific fields.
+ * Configuration class that allows inclusion/exclusion of specific fields.
+ * Also allows to register one or more {@link PropertyEditor}
+ * to customize how field values are added to the HTTP request
  */
 public class Configuration {
 
@@ -17,21 +23,23 @@ public class Configuration {
             .build();
     public static final Configuration EXCLUDE_FINAL = new Builder()
             .includeFinal(false)
-            .includeTransient(true)
+            .includeTransient(false)
             .build();
     public static final Configuration INCLUDE_TRANSIENT = new Builder()
-            .includeFinal(false)
             .includeTransient(true)
+            .includeFinal(false)
             .build();
     public static final Configuration INCLUDE_STATIC = new Builder()
-            .includeFinal(false)
             .includeStatic(true)
+            .includeFinal(false)
             .build();
 
     private final Predicate<Field> fieldPredicate;
+    private final PropertyEditorRegistrySupport propertyEditorRegistrySupport;
 
-    private Configuration(Predicate<Field> fieldPredicate) {
+    private Configuration(Predicate<Field> fieldPredicate, PropertyEditorRegistrySupport propertyEditorRegistrySupport) {
         this.fieldPredicate = fieldPredicate;
+        this.propertyEditorRegistrySupport = propertyEditorRegistrySupport;
     }
 
     /**
@@ -45,32 +53,28 @@ public class Configuration {
         return fieldPredicate;
     }
 
+    public PropertyEditor propertyEditorFor(Class<?> propertyEditorClass) {
+        return this.propertyEditorRegistrySupport.hasCustomEditorForElement(propertyEditorClass, null) ?
+                this.propertyEditorRegistrySupport.findCustomEditor(propertyEditorClass, null) :
+                this.propertyEditorRegistrySupport.getDefaultEditor(propertyEditorClass);
+    }
+
+    public boolean hasPropertyEditorFor(Class<?> propertyEditorClass) {
+        return this.propertyEditorRegistrySupport.hasCustomEditorForElement(propertyEditorClass, null) ||
+               this.propertyEditorRegistrySupport.getDefaultEditor(propertyEditorClass) != null;
+    }
+
     public static class Builder {
 
-        private static final Predicate<Field> BASE_PREDICATE = Builder::isNotSynthetic;
+        private static final Predicate<Field> BASE_PREDICATE = FieldPredicates::isNotSynthetic;
 
+        private final PropertyEditorRegistrySupport propertyEditorRegistrySupport = new PropertyEditorRegistrySupport();
         private Predicate<Field> fieldPredicate;
         private boolean includeFinal = true;
         private boolean includeTransient = false;
         private boolean includeStatic = false;
 
         private Builder() {
-        }
-
-        private static boolean isNotFinal(Field field) {
-            return !Modifier.isFinal(field.getModifiers());
-        }
-
-        private static boolean isNotTransient(Field field) {
-            return !Modifier.isTransient(field.getModifiers());
-        }
-
-        private static boolean isNotStatic(Field field) {
-            return !Modifier.isStatic(field.getModifiers());
-        }
-
-        private static boolean isNotSynthetic(Field field) {
-            return !field.isSynthetic();
         }
 
         public Builder fieldPredicate(Predicate<Field> fieldPredicate) {
@@ -93,24 +97,47 @@ public class Configuration {
             return this;
         }
 
+        public Builder withPropertyEditor(PropertyEditorSupport propertyEditor, Class<?> propertyEditorClass) {
+            Objects.requireNonNull(propertyEditor, "propertyEditor cannot be null");
+            this.propertyEditorRegistrySupport.registerCustomEditor(propertyEditorClass, propertyEditor);
+            return this;
+        }
+
         public Configuration build() {
             Predicate<Field> fieldPredicate = this.fieldPredicate != null ? BASE_PREDICATE.and(this.fieldPredicate) : BASE_PREDICATE;
 
             if (!this.includeFinal) {
-                fieldPredicate = fieldPredicate.and(Builder::isNotFinal);
+                fieldPredicate = fieldPredicate.and(FieldPredicates::isNotFinal);
             }
 
             if (!this.includeTransient) {
-                fieldPredicate = fieldPredicate.and(Builder::isNotTransient);
+                fieldPredicate = fieldPredicate.and(FieldPredicates::isNotTransient);
             }
 
             if (!this.includeStatic) {
-                fieldPredicate = fieldPredicate.and(Builder::isNotStatic);
+                fieldPredicate = fieldPredicate.and(FieldPredicates::isNotStatic);
             }
 
-            return new Configuration(fieldPredicate);
+            return new Configuration(fieldPredicate, this.propertyEditorRegistrySupport);
         }
-
     }
 
+    static class FieldPredicates {
+
+        public static boolean isNotFinal(Field field) {
+            return !Modifier.isFinal(field.getModifiers());
+        }
+
+        public static boolean isNotTransient(Field field) {
+            return !Modifier.isTransient(field.getModifiers());
+        }
+
+        public static boolean isNotStatic(Field field) {
+            return !Modifier.isStatic(field.getModifiers());
+        }
+
+        public static boolean isNotSynthetic(Field field) {
+            return !field.isSynthetic();
+        }
+    }
 }

--- a/spring-mvc-test-utils/src/main/java/io/florianlopes/spring/test/web/servlet/request/Configuration.java
+++ b/spring-mvc-test-utils/src/main/java/io/florianlopes/spring/test/web/servlet/request/Configuration.java
@@ -124,6 +124,9 @@ public class Configuration {
 
     static class FieldPredicates {
 
+        private FieldPredicates() {
+        }
+
         public static boolean isNotFinal(Field field) {
             return !Modifier.isFinal(field.getModifiers());
         }

--- a/spring-mvc-test-utils/src/main/java/io/florianlopes/spring/test/web/servlet/request/FormFieldWrapper.java
+++ b/spring-mvc-test-utils/src/main/java/io/florianlopes/spring/test/web/servlet/request/FormFieldWrapper.java
@@ -1,0 +1,246 @@
+package io.florianlopes.spring.test.web.servlet.request;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.reflect.FieldUtils;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.util.ClassUtils;
+import org.springframework.util.CollectionUtils;
+
+import java.beans.PropertyEditor;
+import java.lang.reflect.Field;
+import java.lang.reflect.ParameterizedType;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.time.temporal.Temporal;
+import java.util.*;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.StreamSupport;
+
+class FormFieldWrapper {
+
+    private final Field rawField;
+    private final FormFieldWrapper parent;
+
+    private final Object targetObject;
+    private final String indexOrPosition;
+
+    private final Configuration configuration;
+
+    private final List<FormFieldWrapper> children;
+
+    FormFieldWrapper(Field rawField, FormFieldWrapper parent, Object targetObject,
+                     String indexOrPosition, Configuration configuration) {
+        this.rawField = rawField;
+        this.parent = parent;
+        this.targetObject = targetObject;
+        this.indexOrPosition = indexOrPosition;
+        this.configuration = configuration;
+
+        if (this.targetObject != null) {
+            this.children = discoverChildren();
+        } else {
+            this.children = Collections.emptyList();
+        }
+    }
+
+    FormFieldWrapper(Object form, Configuration config) {
+        this(null, null, form, null, config);
+    }
+
+    private FormFieldWrapper(Field rawField, FormFieldWrapper parent, Object targetObject) {
+        this(rawField, parent, targetObject, null, null);
+    }
+
+    private FormFieldWrapper(FormFieldWrapper parent, Object targetObject, String indexOrPosition) {
+        this(null, parent, targetObject, indexOrPosition, null);
+    }
+
+    private static FormFieldWrapper newSimpleFieldWrapper(Field rawField, FormFieldWrapper parent, Object targetObject) {
+        return new FormFieldWrapper(rawField, parent, targetObject);
+    }
+
+    private static FormFieldWrapper newMapFieldWrapper(FormFieldWrapper parent, Object targetObject, String index) {
+        return new FormFieldWrapper(parent, targetObject, index);
+    }
+
+    private static FormFieldWrapper newIterableFieldWrapper(FormFieldWrapper parent, Object targetObject, String position) {
+        return new FormFieldWrapper(parent, targetObject, position);
+    }
+
+    Map<String, String> collectFields() {
+        final Map<String, String> fields = new HashMap<>();
+        if (hasChildren()) {
+            fields.putAll(collectChildrenFields());
+        } else {
+            if (this.targetObject != null || this.parent != null && this.parent.isMap()) {
+                fields.put(getNestedPath(), stringRepresentation());
+            }
+        }
+        return fields;
+    }
+
+    private Map<String, String> collectChildrenFields() {
+        final Map<String, String> fields = new HashMap<>();
+        this.children.forEach(child -> {
+            if (child.hasChildren()) {
+                child.getChildren().forEach(
+                        grandChild -> fields.putAll(grandChild.collectFields())
+                );
+            } else if (child.getTargetObject() != null) {
+                fields.put(child.getNestedPath(), child.stringRepresentation());
+            }
+        });
+        return fields;
+    }
+
+    private List<FormFieldWrapper> discoverChildren() {
+        final List<FormFieldWrapper> children = new ArrayList<>();
+
+        if (isIterable()) {
+            final Iterable<?> iterableTargetObject =
+                    Iterable.class.isAssignableFrom(this.rawField.getType()) ?
+                            (Iterable<?>) targetObject :
+                            CollectionUtils.arrayToList(targetObject);
+
+            final AtomicInteger position = new AtomicInteger(0);
+            StreamSupport.stream(iterableTargetObject.spliterator(), false)
+                    .forEach(object -> children.add(
+                            newIterableFieldWrapper(
+                                    this,
+                                    object,
+                                    String.valueOf(position.getAndIncrement())
+                            )
+                    ));
+        } else if (isMap()) {
+            final Map<?, ?> mapTargetObject = (Map<?, ?>) this.targetObject;
+            mapTargetObject.forEach((key, value) -> children.add(
+                    newMapFieldWrapper(
+                            this,
+                            value,
+                            String.valueOf(key)
+                    )
+            ));
+        } else if (isComplex()) {
+            FieldUtils.getAllFieldsList(targetObject.getClass())
+                    .stream()
+                    .filter(getConfiguration().fieldPredicate())
+                    .forEach(field -> children.add(
+                            newSimpleFieldWrapper(
+                                    field,
+                                    this,
+                                    ReflectionTestUtils.getField(targetObject, field.getName())
+                            )
+                    ));
+        }
+
+        return children;
+    }
+
+    private boolean isComplex() {
+        if (this.rawField != null) {
+            final Class<?> fieldType = getFieldType();
+            if (fieldType.isAssignableFrom(BigInteger.class) || fieldType.isAssignableFrom(BigDecimal.class)) {
+                return false;
+            } else {
+                return isComplexType(fieldType);
+            }
+        } else {
+            return isComplexType(this.targetObject.getClass());
+        }
+    }
+
+    private boolean isComplexType(Class<?> type) {
+        if (type.getComponentType() != null) {
+            return isComplexType(type.getComponentType());
+        }
+        return !ClassUtils.isPrimitiveOrWrapper(type)
+               && !String.class.isAssignableFrom(type)
+               && !Date.class.isAssignableFrom(type)
+               && !Temporal.class.isAssignableFrom(type)
+               && type.getSuperclass() != null
+               && !Enum.class.isAssignableFrom(type.getSuperclass());
+    }
+
+    private boolean isGeneric() {
+        return this.rawField != null && !(this.rawField.getGenericType() instanceof Class);
+    }
+
+    private boolean isMap() {
+        return this.rawField != null && Map.class.isAssignableFrom(this.rawField.getType());
+    }
+
+    private boolean isIterable() {
+        return this.rawField != null &&
+               (Iterable.class.isAssignableFrom(this.rawField.getType()) || Object[].class.isAssignableFrom(this.rawField.getType()));
+    }
+
+    private Object getTargetObject() {
+        return targetObject;
+    }
+
+    private List<FormFieldWrapper> getChildren() {
+        return this.children;
+    }
+
+    private FormFieldWrapper getParent() {
+        return parent;
+    }
+
+    private Configuration getConfiguration() {
+        if (this.configuration == null && this.parent != null) {
+            return this.parent.getConfiguration();
+        }
+        return this.configuration;
+    }
+
+    private String getIndex() {
+        return indexOrPosition;
+    }
+
+    private Class<?> getFieldType() {
+        if (isGeneric()) {
+            final ParameterizedType genericType = (ParameterizedType) this.rawField.getGenericType();
+            return (Class<?>) genericType.getActualTypeArguments()[0];
+        } else {
+            return this.rawField.getType();
+        }
+    }
+
+    private String getPath() {
+        return this.rawField != null ? this.rawField.getName() : StringUtils.EMPTY;
+    }
+
+    private String getNestedPath() {
+        final String path = getPath();
+        if (this.parent != null) {
+            if (this.parent.hasIndexOrPosition()) {
+                return String.format("%s[%s].%s", this.parent.getParent().getNestedPath(), this.parent.getIndex(), path);
+            } else if (StringUtils.isNotEmpty(this.parent.getNestedPath())) {
+                if (this.hasIndexOrPosition()) {
+                    return String.format("%s[%s]%s", this.parent.getNestedPath(), this.getIndex(), path);
+                } else {
+                    return String.format("%s.%s", this.parent.getNestedPath(), path);
+                }
+            }
+        }
+        return path;
+    }
+
+    private String stringRepresentation() {
+        if (this.rawField != null && getConfiguration().hasPropertyEditorFor(this.getFieldType())) {
+            final PropertyEditor propertyEditor = getConfiguration().propertyEditorFor(this.getFieldType());
+            propertyEditor.setValue(this.targetObject);
+            return propertyEditor.getAsText();
+        } else {
+            return this.targetObject != null ? String.valueOf(this.targetObject) : StringUtils.EMPTY;
+        }
+    }
+
+    private boolean hasIndexOrPosition() {
+        return StringUtils.isNotEmpty(this.indexOrPosition);
+    }
+
+    private boolean hasChildren() {
+        return !this.children.isEmpty();
+    }
+}

--- a/spring-mvc-test-utils/src/main/java/io/florianlopes/spring/test/web/servlet/request/FormFieldWrapper.java
+++ b/spring-mvc-test-utils/src/main/java/io/florianlopes/spring/test/web/servlet/request/FormFieldWrapper.java
@@ -193,7 +193,7 @@ class FormFieldWrapper {
         return this.configuration;
     }
 
-    private String getIndex() {
+    private String getIndexOrPosition() {
         return indexOrPosition;
     }
 
@@ -214,10 +214,10 @@ class FormFieldWrapper {
         final String path = getPath();
         if (this.parent != null) {
             if (this.parent.hasIndexOrPosition()) {
-                return String.format("%s[%s].%s", this.parent.getParent().getNestedPath(), this.parent.getIndex(), path);
+                return String.format("%s[%s].%s", this.parent.getParent().getNestedPath(), this.parent.getIndexOrPosition(), path);
             } else if (StringUtils.isNotEmpty(this.parent.getNestedPath())) {
                 if (this.hasIndexOrPosition()) {
-                    return String.format("%s[%s]%s", this.parent.getNestedPath(), this.getIndex(), path);
+                    return String.format("%s[%s]%s", this.parent.getNestedPath(), this.getIndexOrPosition(), path);
                 } else {
                     return String.format("%s.%s", this.parent.getNestedPath(), path);
                 }

--- a/spring-mvc-test-utils/src/main/java/io/florianlopes/spring/test/web/servlet/request/FormRequestPostProcessor.java
+++ b/spring-mvc-test-utils/src/main/java/io/florianlopes/spring/test/web/servlet/request/FormRequestPostProcessor.java
@@ -1,0 +1,38 @@
+package io.florianlopes.spring.test.web.servlet.request;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.test.web.servlet.request.RequestPostProcessor;
+
+import java.util.Map;
+
+/**
+ * Implementation of {@link RequestPostProcessor} that adds form parameters to the request before execution.
+ *
+ * @see MockMvcRequestBuilderUtils#postForm(String, Object) for implementation details
+ */
+public class FormRequestPostProcessor implements RequestPostProcessor {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(FormRequestPostProcessor.class);
+
+    private final Object form;
+    private final Configuration config;
+
+    FormRequestPostProcessor(Object form, Configuration config) {
+        this.form = form;
+        this.config = config;
+    }
+
+    @Override
+    public MockHttpServletRequest postProcessRequest(MockHttpServletRequest request) {
+        final Map<String, String> formFields = new FormFieldWrapper(form, config).collectFields();
+
+        formFields.forEach((fieldName, fieldValue) -> {
+            LOGGER.trace("Adding form field ({}={}) to HTTP request parameters", fieldName, fieldValue);
+            request.addParameter(fieldName, fieldValue);
+        });
+
+        return request;
+    }
+}

--- a/spring-mvc-test-utils/src/main/java/io/florianlopes/spring/test/web/servlet/request/MockMvcRequestBuilderUtils.java
+++ b/spring-mvc-test-utils/src/main/java/io/florianlopes/spring/test/web/servlet/request/MockMvcRequestBuilderUtils.java
@@ -1,73 +1,28 @@
 package io.florianlopes.spring.test.web.servlet.request;
 
-import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.reflect.FieldUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.PropertyEditorRegistrySupport;
-import org.springframework.beans.SimpleTypeConverter;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
-import org.springframework.mock.web.MockHttpServletRequest;
-import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
-import org.springframework.test.web.servlet.request.RequestPostProcessor;
-import org.springframework.util.ClassUtils;
-import org.springframework.util.CollectionUtils;
 
-import java.beans.PropertyEditor;
-import java.lang.reflect.Field;
-import java.lang.reflect.ParameterizedType;
-import java.lang.reflect.Type;
-import java.time.temporal.Temporal;
-import java.util.*;
-import java.util.stream.Collectors;
+import java.util.Map;
 
 /**
  * Custom MockMvcRequestBuilder to post an entire form to a given url.
  * Useful to test Spring MVC form validation.
  *
  * @author Florian Lopes
- * @see org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+ * @see MockMvcRequestBuilders
  */
 public class MockMvcRequestBuilderUtils {
 
-    private static final PropertyEditorRegistrySupport PROPERTY_EDITOR_REGISTRY = new SimpleTypeConverter();
-    private static final Configuration DEFAULT_CONFIG = Configuration.DEFAULT;
-
     private static final Logger LOGGER = LoggerFactory.getLogger(MockMvcRequestBuilderUtils.class);
 
+    private static final Configuration DEFAULT_CONFIG = Configuration.DEFAULT;
+
     private MockMvcRequestBuilderUtils() {
-    }
-
-    /**
-     * Register custom property editor for a given type.
-     *
-     * @param type           type of the property
-     * @param propertyEditor {@link PropertyEditor} to register
-     */
-    public static void registerPropertyEditor(Class type, PropertyEditor propertyEditor) {
-        PROPERTY_EDITOR_REGISTRY.registerCustomEditor(type, propertyEditor);
-    }
-
-    public static FormRequestPostProcessor form(Object form) {
-        return form(form, DEFAULT_CONFIG);
-    }
-
-    public static FormRequestPostProcessor form(Object form, Configuration config) {
-        return new FormRequestPostProcessor(form, config);
-    }
-
-    /**
-     * Post a form to the given url.
-     * All non-null, non-static, non-final, non-transient form fields will be added as HTTP request parameters using POST method
-     *
-     * @param url  the URL to post the form to
-     * @param form form object to send using POST method
-     * @return mockHttpServletRequestBuilder wrapped mockHttpServletRequestBuilder
-     */
-    public static MockHttpServletRequestBuilder postForm(String url, Object form) {
-        return postForm(url, form, DEFAULT_CONFIG);
     }
 
     /**
@@ -80,21 +35,19 @@ public class MockMvcRequestBuilderUtils {
      * @return mockHttpServletRequestBuilder wrapped mockHttpServletRequestBuilder
      */
     public static MockHttpServletRequestBuilder postForm(String url, Object form, Configuration config) {
-        final MockHttpServletRequestBuilder mockHttpServletRequestBuilder = MockMvcRequestBuilders.post(url)
-                .contentType(MediaType.APPLICATION_FORM_URLENCODED);
-        return buildFormFields(form, mockHttpServletRequestBuilder, config);
+        return buildMockHttpServletRequestBuilder(url, form, config, HttpMethod.POST);
     }
 
     /**
-     * Put a form to the given url.
-     * All non-null, non-static, non-final, non-transient form fields will be added as HTTP request parameters using PUT method
+     * Post a form to the given url.
+     * All non-null, non-static, non-final, non-transient form fields will be added as HTTP request parameters using POST method
      *
-     * @param url  the URL to put the form to
-     * @param form form object to send using PUT method
+     * @param url  the URL to post the form to
+     * @param form form object to send using POST method
      * @return mockHttpServletRequestBuilder wrapped mockHttpServletRequestBuilder
      */
-    public static MockHttpServletRequestBuilder putForm(String url, Object form) {
-        return putForm(url, form, DEFAULT_CONFIG);
+    public static MockHttpServletRequestBuilder postForm(String url, Object form) {
+        return buildMockHttpServletRequestBuilder(url, form, DEFAULT_CONFIG, HttpMethod.POST);
     }
 
     /**
@@ -107,182 +60,66 @@ public class MockMvcRequestBuilderUtils {
      * @return mockHttpServletRequestBuilder wrapped mockHttpServletRequestBuilder
      */
     public static MockHttpServletRequestBuilder putForm(String url, Object form, Configuration config) {
-        final MockHttpServletRequestBuilder mockHttpServletRequestBuilder = MockMvcRequestBuilders.put(url)
-                .contentType(MediaType.APPLICATION_FORM_URLENCODED);
-        return buildFormFields(form, mockHttpServletRequestBuilder, config);
-    }
-
-    private static MockHttpServletRequestBuilder buildFormFields(Object form, MockHttpServletRequestBuilder mockHttpServletRequestBuilder, Configuration config) {
-        final Map<String, String> formFields = getFormFields(form, new TreeMap<>(), StringUtils.EMPTY, config);
-        formFields.forEach((path, value) -> {
-            LOGGER.debug("Adding form field ({}={}) to HTTP request parameters", path, value);
-            mockHttpServletRequestBuilder.param(path, value);
-        });
-
-        return mockHttpServletRequestBuilder;
-    }
-
-    private static Map<String, String> getFormFields(Object form, Map<String, String> formFields, String path, Configuration config) {
-        final List<Field> fields = form != null ? getFormFields(form, config) : new ArrayList<>();
-        for (Field field : fields) {
-            final Class<?> fieldType = field.getType();
-            final Object fieldValue = getFieldValue(form, field);
-            if (fieldValue != null) {
-                if (isIterable(fieldType)) {
-                    final Iterable<?> iterableObject = getIterable(fieldValue, fieldType);
-                    if (iterableObject != null) {
-                        if (isComplexField(field)) {
-                            int i = 0;
-                            for (Object object : iterableObject) {
-                                final String nestedPath = getPositionedField(path, field, i) + ".";
-                                formFields.putAll(getFormFields(object, formFields, nestedPath, config));
-                                i++;
-                            }
-                        } else {
-                            formFields.putAll(getCollectionFields(iterableObject, path, field));
-                        }
-                    }
-                } else if (isMap(fieldType)) {
-                    final Map<?, ?> map = getMap(fieldValue, fieldType);
-                    if (map != null) {
-                        map.forEach((key, value) -> formFields.put(getPositionedField(path, field, getStringValue(key)), getStringValue(value)));
-                    }
-                } else {
-                    if (!isComplexField(field) || hasPropertyEditorFor(fieldType)) {
-                        // Resolve field's value either using a property editor or its string representation
-                        formFields.put(path + field.getName(), getStringValue(fieldValue));
-                    } else {
-                        // Iterate over object's fields
-                        final String nestedPath = getNestedPath(field);
-                        formFields.putAll(getFormFields(ReflectionTestUtils.getField(form, field.getName()), formFields, nestedPath, config));
-                    }
-                }
-            }
-        }
-        return formFields;
-    }
-
-    private static List<Field> getFormFields(Object form, Configuration config) {
-        return FieldUtils.getAllFieldsList(form.getClass())
-                .stream()
-                .filter(config.fieldPredicate())
-                .collect(Collectors.toList());
-    }
-
-    private static Map<?, ?> getMap(Object fieldValue, Class<?> type) {
-        return Map.class.isAssignableFrom(type) ? (Map) fieldValue : null;
-    }
-
-    private static Iterable<?> getIterable(Object fieldValue, Class<?> type) {
-        return Iterable.class.isAssignableFrom(type) ? (Iterable<?>) fieldValue : CollectionUtils.arrayToList(fieldValue);
-    }
-
-    private static Map<String, String> getCollectionFields(Iterable<?> iterable, String path, Field field) {
-        final Map<String, String> fields = new TreeMap<>();
-        int i = 0;
-        for (Object object : iterable) {
-            fields.put(getPositionedField(path, field, i), getStringValue(object));
-            i++;
-        }
-        return fields;
-    }
-
-    private static String getPositionedField(String path, Field field, int position) {
-        return getPositionedField(path, field, String.valueOf(position));
-    }
-
-    private static String getPositionedField(String path, Field field, String positionOrKey) {
-        return String.format("%s%s[%s]", path, field.getName(), positionOrKey);
-    }
-
-    private static String getNestedPath(Field field) {
-        return field.getName() + ".";
-    }
-
-    private static Object getFieldValue(Object form, Field field) {
-        return ReflectionTestUtils.getField(form, field.getName());
-    }
-
-    private static String getStringValue(Object object) {
-        if (object != null) {
-            final PropertyEditor propertyEditor = getPropertyEditorFor(object);
-            if (propertyEditor != null) {
-                propertyEditor.setValue(object);
-                return propertyEditor.getAsText();
-            }
-            // Default strategy
-            return String.valueOf(object);
-        }
-        return StringUtils.EMPTY;
-    }
-
-    private static boolean hasPropertyEditorFor(Class<?> type) {
-        return PROPERTY_EDITOR_REGISTRY.hasCustomEditorForElement(type, null) ||
-               PROPERTY_EDITOR_REGISTRY.getDefaultEditor(type) != null;
-    }
-
-    private static PropertyEditor getPropertyEditorFor(Object object) {
-        return PROPERTY_EDITOR_REGISTRY.hasCustomEditorForElement(object.getClass(), null) ? PROPERTY_EDITOR_REGISTRY.findCustomEditor(object.getClass(), null)
-                : PROPERTY_EDITOR_REGISTRY.getDefaultEditor(object.getClass());
-    }
-
-    private static boolean isComplexField(Field field) {
-        if (isGeneric(field)) {
-            final ParameterizedType genericType = (ParameterizedType) field.getGenericType();
-            final Type[] actualTypeArguments = genericType.getActualTypeArguments();
-            return isComplexType((Class<?>) actualTypeArguments[0]);
-        } else {
-            return isComplexType(field.getType());
-        }
-    }
-
-    private static boolean isGeneric(Field field) {
-        return !(field.getGenericType() instanceof Class);
-    }
-
-    private static boolean isComplexType(Class<?> type) {
-        if (type.getComponentType() != null) {
-            return isComplexType(type.getComponentType());
-        }
-        return !ClassUtils.isPrimitiveOrWrapper(type)
-               && !String.class.isAssignableFrom(type)
-               && !Date.class.isAssignableFrom(type)
-               && !Temporal.class.isAssignableFrom(type)
-               && type.getSuperclass() != null
-               && !Enum.class.isAssignableFrom(type.getSuperclass());
-    }
-
-    private static boolean isIterable(Class fieldClass) {
-        return Iterable.class.isAssignableFrom(fieldClass) || Object[].class.isAssignableFrom(fieldClass);
-    }
-
-    private static boolean isMap(Class<?> type) {
-        return Map.class.isAssignableFrom(type);
+        return buildMockHttpServletRequestBuilder(url, form, config, HttpMethod.PUT);
     }
 
     /**
-     * Implementation of {@link RequestPostProcessor} that adds form parameters to the request before execution.
+     * Put a form to the given url.
+     * All non-null, non-static, non-final, non-transient form fields will be added as HTTP request parameters using PUT method
      *
-     * @see MockMvcRequestBuilderUtils#postForm(String, Object) for implementation details
+     * @param url  the URL to put the form to
+     * @param form form object to send using PUT method
+     * @return mockHttpServletRequestBuilder wrapped mockHttpServletRequestBuilder
      */
-    public static class FormRequestPostProcessor implements RequestPostProcessor {
+    public static MockHttpServletRequestBuilder putForm(String url, Object form) {
+        return buildMockHttpServletRequestBuilder(url, form, DEFAULT_CONFIG, HttpMethod.PUT);
+    }
 
-        private final Object form;
-        private final Configuration config;
+    /**
+     * Creates a FormRequestPostProcessor that can be used to add form parameters to an HTTP request.
+     *
+     * @param form   the form object from which to extract HTTP request parameters
+     * @param config the configuration object that customizes how the fields are processed
+     * @return a FormRequestPostProcessor that adds the form parameters to the HTTP request
+     */
+    public static FormRequestPostProcessor form(Object form, Configuration config) {
+        return new FormRequestPostProcessor(form, config);
+    }
 
-        private FormRequestPostProcessor(Object form, Configuration config) {
-            this.form = form;
-            this.config = config;
-        }
+    /**
+     * Creates a FormRequestPostProcessor that can be used to add form parameters to an HTTP request.
+     * Uses the default configuration
+     *
+     * @param form the form object from which to extract HTTP request parameters
+     * @return a FormRequestPostProcessor that adds the form parameters to the HTTP request
+     * @see Configuration#DEFAULT
+     */
+    public static FormRequestPostProcessor form(Object form) {
+        return form(form, DEFAULT_CONFIG);
+    }
 
-        @Override
-        public MockHttpServletRequest postProcessRequest(MockHttpServletRequest request) {
-            final Map<String, String> formFields = getFormFields(form, new TreeMap<>(), StringUtils.EMPTY, config);
-            formFields.forEach((path, value) -> {
-                LOGGER.debug("Adding form field ({}={}) to HTTP request parameters", path, value);
-                request.addParameter(path, value);
-            });
-            return request;
-        }
+    private static MockHttpServletRequestBuilder buildMockHttpServletRequestBuilder(
+            String url,
+            Object form,
+            Configuration config,
+            HttpMethod method
+    ) {
+        final MockHttpServletRequestBuilder builder = MockMvcRequestBuilders.request(method, url)
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED);
+        addFormFieldsToRequestBuilder(form, builder, config);
+        return builder;
+    }
+
+    private static void addFormFieldsToRequestBuilder(
+            Object form,
+            MockHttpServletRequestBuilder mockHttpServletRequestBuilder,
+            Configuration config
+    ) {
+        final Map<String, String> formFields = new FormFieldWrapper(form, config).collectFields();
+
+        formFields.forEach((fieldName, fieldValue) -> {
+            LOGGER.trace("Adding form field ({}={}) to HTTP request parameters", fieldName, fieldValue);
+            mockHttpServletRequestBuilder.param(fieldName, fieldValue);
+        });
     }
 }

--- a/spring-mvc-test-utils/src/test/java/io/florianlopes/spring/test/web/servlet/request/AddUserForm.java
+++ b/spring-mvc-test-utils/src/test/java/io/florianlopes/spring/test/web/servlet/request/AddUserForm.java
@@ -2,10 +2,7 @@ package io.florianlopes.spring.test.web.servlet.request;
 
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import org.springframework.format.annotation.DateTimeFormat;
 
 import java.math.BigDecimal;
@@ -34,7 +31,7 @@ class AddUserForm {
     @NotNull
     private Gender gender;
     @NotNull
-    @DateTimeFormat(pattern = "dd/MM/yyyy")
+    @DateTimeFormat(pattern = "dd.MM.yyyy")
     private LocalDate birthDate;
     @NotNull
     private Address currentAddress;
@@ -48,6 +45,8 @@ class AddUserForm {
     private Address[] formerAddresses;
     @NotEmpty
     private Map<String, String> metadatas;
+    @NotEmpty
+    private Map<String, Diploma> diplomasMap;
 
     AddUserForm(String firstName, String name, LocalDate birthDate, Address currentAddress) {
         this.firstName = firstName;
@@ -66,7 +65,7 @@ class AddUserForm {
     static class Diploma {
         @NotEmpty
         private String name;
-        @DateTimeFormat(pattern = "dd/MM/yyyy")
+        @DateTimeFormat(pattern = "dd.MM.yyyy")
         @NotNull
         private LocalDate date;
 
@@ -78,6 +77,7 @@ class AddUserForm {
 
     @Data
     @NoArgsConstructor
+    @With
     static class Address {
         @NotNull
         private int streetNumber;
@@ -87,6 +87,16 @@ class AddUserForm {
         private int postalCode;
         @NotEmpty
         private String city;
+
+        private Address linkedAddress;
+
+        public Address(int streetNumber, String streetName, int postalCode, String city, Address linkedAddress) {
+            this.streetNumber = streetNumber;
+            this.streetName = streetName;
+            this.postalCode = postalCode;
+            this.city = city;
+            this.linkedAddress = linkedAddress;
+        }
 
         Address(int streetNumber, String streetName, int postalCode, String city) {
             this.streetNumber = streetNumber;

--- a/spring-mvc-test-utils/src/test/java/io/florianlopes/spring/test/web/servlet/request/ConfigurationForm.java
+++ b/spring-mvc-test-utils/src/test/java/io/florianlopes/spring/test/web/servlet/request/ConfigurationForm.java
@@ -20,6 +20,8 @@ public class ConfigurationForm {
     private transient String transientName;
     private Inner inner;
 
+    private String simpleField;
+
     @Data
     @AllArgsConstructor
     public static class Inner {

--- a/spring-mvc-test-utils/src/test/java/io/florianlopes/spring/test/web/servlet/request/ConfigurationTests.java
+++ b/spring-mvc-test-utils/src/test/java/io/florianlopes/spring/test/web/servlet/request/ConfigurationTests.java
@@ -70,7 +70,7 @@ class ConfigurationTests {
     }
 
     @Test
-    void registersMultiplePropertyEditor() {
+    void registersMultiplePropertyEditors() {
         final PropertyEditorSupport propertyEditorForBigInteger = new PropertyEditorSupport() {
             @Override
             public String getAsText() {

--- a/spring-mvc-test-utils/src/test/java/io/florianlopes/spring/test/web/servlet/request/ConfigurationTests.java
+++ b/spring-mvc-test-utils/src/test/java/io/florianlopes/spring/test/web/servlet/request/ConfigurationTests.java
@@ -11,13 +11,12 @@ import java.math.BigInteger;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
-public class ConfigurationTests {
+class ConfigurationTests {
 
     @Test
     void throwsIllegalArgumentExceptionWhenFieldPredicateIsNull() {
         assertThrows(NullPointerException.class, () -> Configuration.builder()
-                .fieldPredicate(null)
-                .build());
+                .fieldPredicate(null));
     }
 
     @Test
@@ -67,8 +66,7 @@ public class ConfigurationTests {
     @Test
     void registerNullPropertyEditorThrowsNullPointerException() {
         assertThrows(NullPointerException.class, () -> Configuration.builder()
-                .withPropertyEditor(null, BigInteger.class)
-                .build());
+                .withPropertyEditor(null, BigInteger.class));
     }
 
     @Test
@@ -114,21 +112,21 @@ public class ConfigurationTests {
         private final Configuration defaultConfiguration = Configuration.DEFAULT;
 
         @Test
-        public void includesFinalFields() throws NoSuchFieldException {
+        void includesFinalFields() throws NoSuchFieldException {
             final Field finalField = TestClass.class.getDeclaredField("finalField");
 
             assertTrue(defaultConfiguration.fieldPredicate().test(finalField));
         }
 
         @Test
-        public void excludesTransientFields() throws NoSuchFieldException {
+        void excludesTransientFields() throws NoSuchFieldException {
             final Field transientField = TestClass.class.getDeclaredField("transientField");
 
             assertFalse(defaultConfiguration.fieldPredicate().test(transientField));
         }
 
         @Test
-        public void excludesStaticFields() throws NoSuchFieldException {
+        void excludesStaticFields() throws NoSuchFieldException {
             final Field staticField = TestClass.class.getDeclaredField("STATIC_FIELD");
 
             assertFalse(defaultConfiguration.fieldPredicate().test(staticField));
@@ -141,14 +139,14 @@ public class ConfigurationTests {
         private final Configuration excludeFinalConfiguration = Configuration.EXCLUDE_FINAL;
 
         @Test
-        public void excludesFinalFields() throws NoSuchFieldException {
+        void excludesFinalFields() throws NoSuchFieldException {
             final Field finalField = TestClass.class.getDeclaredField("finalField");
 
             assertFalse(excludeFinalConfiguration.fieldPredicate().test(finalField));
         }
 
         @Test
-        public void excludesTransientFields() throws NoSuchFieldException {
+        void excludesTransientFields() throws NoSuchFieldException {
             final Field transientField = TestClass.class.getDeclaredField("transientField");
 
             assertFalse(excludeFinalConfiguration.fieldPredicate().test(transientField));
@@ -161,14 +159,14 @@ public class ConfigurationTests {
         private final Configuration includeTransientConfiguration = Configuration.INCLUDE_TRANSIENT;
 
         @Test
-        public void includesTransientFields() throws NoSuchFieldException {
+        void includesTransientFields() throws NoSuchFieldException {
             final Field transientField = TestClass.class.getDeclaredField("transientField");
 
             assertTrue(includeTransientConfiguration.fieldPredicate().test(transientField));
         }
 
         @Test
-        public void excludesFinalFields() throws NoSuchFieldException {
+        void excludesFinalFields() throws NoSuchFieldException {
             final Field finalField = TestClass.class.getDeclaredField("finalField");
 
             assertFalse(includeTransientConfiguration.fieldPredicate().test(finalField));
@@ -181,14 +179,14 @@ public class ConfigurationTests {
         private final Configuration includeStaticConfiguration = Configuration.INCLUDE_STATIC;
 
         @Test
-        public void includesStaticFields() throws NoSuchFieldException {
+        void includesStaticFields() throws NoSuchFieldException {
             final Field staticField = TestClass.class.getDeclaredField("STATIC_FIELD");
 
             assertTrue(includeStaticConfiguration.fieldPredicate().test(staticField));
         }
 
         @Test
-        public void excludesFinalFields() throws NoSuchFieldException {
+        void excludesFinalFields() throws NoSuchFieldException {
             final Field finalField = TestClass.class.getDeclaredField("finalField");
 
             assertFalse(includeStaticConfiguration.fieldPredicate().test(finalField));

--- a/spring-mvc-test-utils/src/test/java/io/florianlopes/spring/test/web/servlet/request/ConfigurationTests.java
+++ b/spring-mvc-test-utils/src/test/java/io/florianlopes/spring/test/web/servlet/request/ConfigurationTests.java
@@ -1,0 +1,197 @@
+package io.florianlopes.spring.test.web.servlet.request;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.beans.PropertyEditorSupport;
+import java.lang.reflect.Field;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ConfigurationTests {
+
+    @Test
+    void throwsIllegalArgumentExceptionWhenFieldPredicateIsNull() {
+        assertThrows(NullPointerException.class, () -> Configuration.builder()
+                .fieldPredicate(null)
+                .build());
+    }
+
+    @Test
+    void customPredicate() throws NoSuchFieldException {
+        final Configuration config = Configuration.builder()
+                .fieldPredicate(field -> "simpleField".equals(field.getName()))
+                .build();
+
+        final Field simpleField = TestClass.class.getDeclaredField("simpleField");
+
+        assertTrue(config.fieldPredicate().test(simpleField));
+    }
+
+    @Test
+    void registersPropertyEditor() {
+        final PropertyEditorSupport propertyEditor = new PropertyEditorSupport() {
+            @Override
+            public String getAsText() {
+                return "textValue";
+            }
+        };
+
+        final Configuration config = Configuration.builder()
+                .withPropertyEditor(propertyEditor, BigInteger.class)
+                .build();
+
+        assertThat(config.propertyEditorFor(BigInteger.class)).isEqualTo(propertyEditor);
+    }
+
+    @Test
+    void returnsWhetherPropertyEditorHasBeenRegistered() {
+        final PropertyEditorSupport propertyEditor = new PropertyEditorSupport() {
+            @Override
+            public String getAsText() {
+                return "textValue";
+            }
+        };
+
+        final Configuration config = Configuration.builder()
+                .withPropertyEditor(propertyEditor, BigInteger.class)
+                .build();
+
+        assertTrue(config.hasPropertyEditorFor(BigInteger.class));
+        assertFalse(config.hasPropertyEditorFor(BigDecimal.class));
+    }
+
+    @Test
+    void registerNullPropertyEditorThrowsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> Configuration.builder()
+                .withPropertyEditor(null, BigInteger.class)
+                .build());
+    }
+
+    @Test
+    void registersMultiplePropertyEditor() {
+        final PropertyEditorSupport propertyEditorForBigInteger = new PropertyEditorSupport() {
+            @Override
+            public String getAsText() {
+                return "bigIntegerTextValue";
+            }
+        };
+
+        final PropertyEditorSupport propertyEditorForBigDecimal = new PropertyEditorSupport() {
+            @Override
+            public String getAsText() {
+                return "bigDecimalTextValue";
+            }
+        };
+        final Configuration config = Configuration.builder()
+                .withPropertyEditor(propertyEditorForBigInteger, BigInteger.class)
+                .withPropertyEditor(propertyEditorForBigDecimal, BigDecimal.class)
+                .build();
+
+        assertThat(config.propertyEditorFor(BigInteger.class))
+                .isEqualTo(propertyEditorForBigInteger);
+        assertThat(config.propertyEditorFor(BigDecimal.class))
+                .isEqualTo(propertyEditorForBigDecimal);
+    }
+
+    static class TestClass {
+
+        private static String STATIC_FIELD = "staticFieldValue";
+
+        private final String finalField = "finalFieldValue";
+        private transient String transientField = "transientFieldValue";
+
+        private String simpleField = "simpleFieldValue";
+
+    }
+
+    @Nested
+    class DefaultConfiguration {
+
+        private final Configuration defaultConfiguration = Configuration.DEFAULT;
+
+        @Test
+        public void includesFinalFields() throws NoSuchFieldException {
+            final Field finalField = TestClass.class.getDeclaredField("finalField");
+
+            assertTrue(defaultConfiguration.fieldPredicate().test(finalField));
+        }
+
+        @Test
+        public void excludesTransientFields() throws NoSuchFieldException {
+            final Field transientField = TestClass.class.getDeclaredField("transientField");
+
+            assertFalse(defaultConfiguration.fieldPredicate().test(transientField));
+        }
+
+        @Test
+        public void excludesStaticFields() throws NoSuchFieldException {
+            final Field staticField = TestClass.class.getDeclaredField("STATIC_FIELD");
+
+            assertFalse(defaultConfiguration.fieldPredicate().test(staticField));
+        }
+    }
+
+    @Nested
+    class ExcludeFinalConfiguration {
+
+        private final Configuration excludeFinalConfiguration = Configuration.EXCLUDE_FINAL;
+
+        @Test
+        public void excludesFinalFields() throws NoSuchFieldException {
+            final Field finalField = TestClass.class.getDeclaredField("finalField");
+
+            assertFalse(excludeFinalConfiguration.fieldPredicate().test(finalField));
+        }
+
+        @Test
+        public void excludesTransientFields() throws NoSuchFieldException {
+            final Field transientField = TestClass.class.getDeclaredField("transientField");
+
+            assertFalse(excludeFinalConfiguration.fieldPredicate().test(transientField));
+        }
+    }
+
+    @Nested
+    class IncludeTransientConfiguration {
+
+        private final Configuration includeTransientConfiguration = Configuration.INCLUDE_TRANSIENT;
+
+        @Test
+        public void includesTransientFields() throws NoSuchFieldException {
+            final Field transientField = TestClass.class.getDeclaredField("transientField");
+
+            assertTrue(includeTransientConfiguration.fieldPredicate().test(transientField));
+        }
+
+        @Test
+        public void excludesFinalFields() throws NoSuchFieldException {
+            final Field finalField = TestClass.class.getDeclaredField("finalField");
+
+            assertFalse(includeTransientConfiguration.fieldPredicate().test(finalField));
+        }
+    }
+
+    @Nested
+    class IncludeStaticConfiguration {
+
+        private final Configuration includeStaticConfiguration = Configuration.INCLUDE_STATIC;
+
+        @Test
+        public void includesStaticFields() throws NoSuchFieldException {
+            final Field staticField = TestClass.class.getDeclaredField("STATIC_FIELD");
+
+            assertTrue(includeStaticConfiguration.fieldPredicate().test(staticField));
+        }
+
+        @Test
+        public void excludesFinalFields() throws NoSuchFieldException {
+            final Field finalField = TestClass.class.getDeclaredField("finalField");
+
+            assertFalse(includeStaticConfiguration.fieldPredicate().test(finalField));
+        }
+    }
+}

--- a/spring-mvc-test-utils/src/test/java/io/florianlopes/spring/test/web/servlet/request/CustomLocalDatePropertyEditor.java
+++ b/spring-mvc-test-utils/src/test/java/io/florianlopes/spring/test/web/servlet/request/CustomLocalDatePropertyEditor.java
@@ -2,20 +2,19 @@ package io.florianlopes.spring.test.web.servlet.request;
 
 import org.apache.commons.lang3.StringUtils;
 
-import java.beans.PropertyEditor;
 import java.beans.PropertyEditorSupport;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 
 /**
  * Property editor for {@link java.time.LocalDate}
- * Register this property editor with MockMvcRequestBuilderUtils#registerPropertyEditor
+ * Register this property editor with Configuration.Builder#withPropertyEditor(PropertyEditorSupport, Class)
  *
  * @author Florian Lopes
  * @see java.time.LocalDate
  * @see java.time.format.DateTimeFormatter
  * @see org.springframework.validation.DataBinder#registerCustomEditor
- * @see io.florianlopes.spring.test.web.servlet.request.MockMvcRequestBuilderUtils#registerPropertyEditor(Class, PropertyEditor)
+ * @see Configuration.Builder#withPropertyEditor(PropertyEditorSupport, Class)
  */
 class CustomLocalDatePropertyEditor extends PropertyEditorSupport {
 

--- a/spring-mvc-test-utils/src/test/java/io/florianlopes/spring/test/web/servlet/request/FormRequestPostProcessorTests.java
+++ b/spring-mvc-test-utils/src/test/java/io/florianlopes/spring/test/web/servlet/request/FormRequestPostProcessorTests.java
@@ -37,7 +37,7 @@ class FormRequestPostProcessorTests {
     }
 
     @Test
-    void withParamsNullForm() {
+    void nullForm() {
         final MockHttpServletRequestBuilder mockHttpServletRequestBuilder = MockMvcRequestBuilders.post(POST_FORM_URL)
                 .with(MockMvcRequestBuilderUtils.form(null));
         final MockHttpServletRequest request = mockHttpServletRequestBuilder.buildRequest(servletContext);
@@ -47,7 +47,7 @@ class FormRequestPostProcessorTests {
     }
 
     @Test
-    void withParamsNullAndEmptyFields() {
+    void nullAndEmptyFields() {
         final MockHttpServletRequestBuilder mockHttpServletRequestBuilder = MockMvcRequestBuilders.post(POST_FORM_URL)
                 .with(MockMvcRequestBuilderUtils.form(
                         AddUserForm.builder()
@@ -65,7 +65,7 @@ class FormRequestPostProcessorTests {
     }
 
     @Test
-    void withParamsSimpleFields() {
+    void simpleFields() {
         final AddUserForm addUserForm = AddUserForm.builder()
                 .firstName("John")
                 .currentAddress(TestFixtures.anAddress())
@@ -82,7 +82,7 @@ class FormRequestPostProcessorTests {
     }
 
     @Test
-    void withParamsSimpleCollection() {
+    void simpleCollection() {
         final AddUserForm addUserForm = AddUserForm.builder()
                 .usernames(List.of("john.doe", "jdoe"))
                 .build();
@@ -97,7 +97,7 @@ class FormRequestPostProcessorTests {
     }
 
     @Test
-    void withParamsComplexCollection() {
+    void complexCollection() {
         final AddUserForm addUserForm = AddUserForm.builder()
                 .diplomas(List.of(
                         new AddUserForm.Diploma("License", LocalDate.now().minusYears(2)),
@@ -119,7 +119,7 @@ class FormRequestPostProcessorTests {
     }
 
     @Test
-    void withParamsSimpleArray() {
+    void simpleArray() {
         final AddUserForm addUserForm = AddUserForm.builder()
                 .usernamesArray(new String[]{"john.doe", "jdoe"})
                 .build();
@@ -133,7 +133,7 @@ class FormRequestPostProcessorTests {
     }
 
     @Test
-    void withParamsComplexArray() {
+    void complexArray() {
         final AddUserForm addUserForm = AddUserForm.builder()
                 .formerAddresses(new AddUserForm.Address[]{
                         new AddUserForm.Address(10, "Street 10", 5222, "Chicago"),
@@ -156,7 +156,7 @@ class FormRequestPostProcessorTests {
     }
 
     @Test
-    void withParamsEnumField() {
+    void enumField() {
         final AddUserForm addUserForm = AddUserForm.builder()
                 .gender(AddUserForm.Gender.MALE)
                 .build();
@@ -169,7 +169,7 @@ class FormRequestPostProcessorTests {
     }
 
     @Test
-    void withParamsSimpleMapField() {
+    void simpleMapField() {
         final Map<String, String> metadatas = new HashMap<>();
         metadatas.put("firstName", "John");
         metadatas.put("name", "Doe");
@@ -188,7 +188,7 @@ class FormRequestPostProcessorTests {
     }
 
     @Test
-    void withParamsComplexMapField() {
+    void complexMapField() {
         final LocalDate mscDate = LocalDate.now();
         final LocalDate licenseDate = LocalDate.now().minusYears(2);
         final AddUserForm addUserForm = AddUserForm.builder()
@@ -212,7 +212,7 @@ class FormRequestPostProcessorTests {
     }
 
     @Test
-    void withParamsBigDecimal() {
+    void bigDecimal() {
         final AddUserForm addUserForm = AddUserForm.builder()
                 .identificationNumber(BigDecimal.TEN)
                 .build();
@@ -225,7 +225,7 @@ class FormRequestPostProcessorTests {
     }
 
     @Test
-    void withParamsBigInteger() {
+    void bigInteger() {
         final AddUserForm addUserForm = AddUserForm.builder()
                 .identificationNumberBigInt(BigInteger.TEN)
                 .build();
@@ -238,7 +238,7 @@ class FormRequestPostProcessorTests {
     }
 
     @Test
-    void withParamsRegisterPropertyEditor() {
+    void registerPropertyEditor() {
         // Registering a property editor should override default conversion strategy
         final PropertyEditorSupport bigIntegerPropertyEditor = new PropertyEditorSupport() {
             @Override

--- a/spring-mvc-test-utils/src/test/java/io/florianlopes/spring/test/web/servlet/request/FormRequestPostProcessorTests.java
+++ b/spring-mvc-test-utils/src/test/java/io/florianlopes/spring/test/web/servlet/request/FormRequestPostProcessorTests.java
@@ -1,0 +1,279 @@
+package io.florianlopes.spring.test.web.servlet.request;
+
+import io.florianlopes.spring.test.web.servlet.request.assertion.RequestParametersAssert;
+import jakarta.servlet.ServletContext;
+import nl.altindag.log.LogCaptor;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockServletContext;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+import java.beans.PropertyEditorSupport;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Nested
+class FormRequestPostProcessorTests {
+
+    private static final LogCaptor LOG_CAPTOR = LogCaptor.forClass(FormRequestPostProcessor.class);
+
+    private static final String POST_FORM_URL = "/test";
+
+    private ServletContext servletContext;
+
+    @BeforeEach
+    void setUp() {
+        this.servletContext = new MockServletContext();
+    }
+
+    @Test
+    void withParamsNullForm() {
+        final MockHttpServletRequestBuilder mockHttpServletRequestBuilder = MockMvcRequestBuilders.post(POST_FORM_URL)
+                .with(MockMvcRequestBuilderUtils.form(null));
+        final MockHttpServletRequest request = mockHttpServletRequestBuilder.buildRequest(servletContext);
+        mockHttpServletRequestBuilder.postProcessRequest(request);
+
+        assertThat(request.getParameterMap()).isEmpty();
+    }
+
+    @Test
+    void withParamsNullAndEmptyFields() {
+        final MockHttpServletRequestBuilder mockHttpServletRequestBuilder = MockMvcRequestBuilders.post(POST_FORM_URL)
+                .with(MockMvcRequestBuilderUtils.form(
+                        AddUserForm.builder()
+                                .firstName("")
+                                .birthDate(null)
+                                .currentAddress(null)
+                                .build()
+                ));
+        final MockHttpServletRequest request = mockHttpServletRequestBuilder.buildRequest(servletContext);
+        mockHttpServletRequestBuilder.postProcessRequest(request);
+
+        assertThat(request.getParameter("firstName")).isEmpty();
+        assertThat(request.getParameter("birthDate")).isNull();
+        assertThat(request.getParameter("currentAddress.city")).isNull();
+    }
+
+    @Test
+    void withParamsSimpleFields() {
+        final AddUserForm addUserForm = AddUserForm.builder()
+                .firstName("John")
+                .currentAddress(TestFixtures.anAddress())
+                .build();
+
+        final MockHttpServletRequestBuilder mockHttpServletRequestBuilder = MockMvcRequestBuilders.post(POST_FORM_URL)
+                .with(MockMvcRequestBuilderUtils.form(addUserForm));
+        final MockHttpServletRequest request = mockHttpServletRequestBuilder.buildRequest(servletContext);
+        mockHttpServletRequestBuilder.postProcessRequest(request);
+
+        assertThat(request.getParameter("firstName")).isEqualTo("John");
+        assertThat(request.getParameter("currentAddress.city"))
+                .isEqualTo(addUserForm.getCurrentAddress().getCity());
+    }
+
+    @Test
+    void withParamsSimpleCollection() {
+        final AddUserForm addUserForm = AddUserForm.builder()
+                .usernames(List.of("john.doe", "jdoe"))
+                .build();
+
+        final MockHttpServletRequestBuilder mockHttpServletRequestBuilder = MockMvcRequestBuilders.post(POST_FORM_URL)
+                .with(MockMvcRequestBuilderUtils.form(addUserForm));
+        final MockHttpServletRequest request = mockHttpServletRequestBuilder.buildRequest(servletContext);
+        mockHttpServletRequestBuilder.postProcessRequest(request);
+
+        assertThat(request.getParameter("usernames[0]")).isEqualTo("john.doe");
+        assertThat(request.getParameter("usernames[1]")).isEqualTo("jdoe");
+    }
+
+    @Test
+    void withParamsComplexCollection() {
+        final AddUserForm addUserForm = AddUserForm.builder()
+                .diplomas(List.of(
+                        new AddUserForm.Diploma("License", LocalDate.now().minusYears(2)),
+                        new AddUserForm.Diploma("MSC", LocalDate.now())
+                ))
+                .build();
+        final MockHttpServletRequestBuilder mockHttpServletRequestBuilder = MockMvcRequestBuilders.post(POST_FORM_URL)
+                .with(MockMvcRequestBuilderUtils.form(addUserForm));
+        final MockHttpServletRequest request = mockHttpServletRequestBuilder.buildRequest(servletContext);
+        mockHttpServletRequestBuilder.postProcessRequest(request);
+
+        RequestParametersAssert.assertThat(request)
+                .containsParameters(Map.of(
+                        "diplomas[0].name", addUserForm.getDiplomas().get(0).getName(),
+                        "diplomas[0].date", addUserForm.getDiplomas().get(0).getDate().format(DateTimeFormatter.ISO_DATE),
+                        "diplomas[1].name", addUserForm.getDiplomas().get(1).getName(),
+                        "diplomas[1].date", addUserForm.getDiplomas().get(1).getDate().format(DateTimeFormatter.ISO_DATE)
+                ));
+    }
+
+    @Test
+    void withParamsSimpleArray() {
+        final AddUserForm addUserForm = AddUserForm.builder()
+                .usernamesArray(new String[]{"john.doe", "jdoe"})
+                .build();
+        final MockHttpServletRequestBuilder mockHttpServletRequestBuilder = MockMvcRequestBuilders.post(POST_FORM_URL)
+                .with(MockMvcRequestBuilderUtils.form(addUserForm));
+        final MockHttpServletRequest request = mockHttpServletRequestBuilder.buildRequest(servletContext);
+        mockHttpServletRequestBuilder.postProcessRequest(request);
+
+        assertThat(request.getParameter("usernamesArray[0]")).isEqualTo("john.doe");
+        assertThat(request.getParameter("usernamesArray[1]")).isEqualTo("jdoe");
+    }
+
+    @Test
+    void withParamsComplexArray() {
+        final AddUserForm addUserForm = AddUserForm.builder()
+                .formerAddresses(new AddUserForm.Address[]{
+                        new AddUserForm.Address(10, "Street 10", 5222, "Chicago"),
+                        new AddUserForm.Address(20, "Street 20", 5222, "Washington")
+                })
+                .build();
+        final MockHttpServletRequestBuilder mockHttpServletRequestBuilder = MockMvcRequestBuilders.post(POST_FORM_URL)
+                .with(MockMvcRequestBuilderUtils.form(addUserForm));
+        final MockHttpServletRequest request = mockHttpServletRequestBuilder.buildRequest(servletContext);
+        mockHttpServletRequestBuilder.postProcessRequest(request);
+
+        assertThat(request.getParameter("formerAddresses[0].streetNumber")).isEqualTo("10");
+        assertThat(request.getParameter("formerAddresses[1].streetNumber")).isEqualTo("20");
+        assertThat(request.getParameter("formerAddresses[0].streetName")).isEqualTo("Street 10");
+        assertThat(request.getParameter("formerAddresses[1].streetName")).isEqualTo("Street 20");
+        assertThat(request.getParameter("formerAddresses[0].city")).isEqualTo("Chicago");
+        assertThat(request.getParameter("formerAddresses[1].city")).isEqualTo("Washington");
+        assertThat(request.getParameter("formerAddresses[0].postalCode")).isEqualTo("5222");
+        assertThat(request.getParameter("formerAddresses[1].postalCode")).isEqualTo("5222");
+    }
+
+    @Test
+    void withParamsEnumField() {
+        final AddUserForm addUserForm = AddUserForm.builder()
+                .gender(AddUserForm.Gender.MALE)
+                .build();
+        final MockHttpServletRequestBuilder mockHttpServletRequestBuilder = MockMvcRequestBuilders.post(POST_FORM_URL)
+                .with(MockMvcRequestBuilderUtils.form(addUserForm));
+        final MockHttpServletRequest request = mockHttpServletRequestBuilder.buildRequest(servletContext);
+        mockHttpServletRequestBuilder.postProcessRequest(request);
+
+        assertThat(request.getParameter("gender")).isEqualTo("MALE");
+    }
+
+    @Test
+    void withParamsSimpleMapField() {
+        final Map<String, String> metadatas = new HashMap<>();
+        metadatas.put("firstName", "John");
+        metadatas.put("name", "Doe");
+        metadatas.put("gender", null);
+        final AddUserForm addUserForm = AddUserForm.builder()
+                .metadatas(metadatas)
+                .build();
+        final MockHttpServletRequestBuilder mockHttpServletRequestBuilder = MockMvcRequestBuilders.post(POST_FORM_URL)
+                .with(MockMvcRequestBuilderUtils.form(addUserForm));
+        final MockHttpServletRequest request = mockHttpServletRequestBuilder.buildRequest(servletContext);
+        mockHttpServletRequestBuilder.postProcessRequest(request);
+
+        assertThat(request.getParameter("metadatas[firstName]")).isEqualTo("John");
+        assertThat(request.getParameter("metadatas[name]")).isEqualTo("Doe");
+        assertThat(request.getParameter("metadatas[gender]")).isEmpty();
+    }
+
+    @Test
+    void withParamsComplexMapField() {
+        final LocalDate mscDate = LocalDate.now();
+        final LocalDate licenseDate = LocalDate.now().minusYears(2);
+        final AddUserForm addUserForm = AddUserForm.builder()
+                .diplomasMap(Map.of(
+                        "License", new AddUserForm.Diploma("License", licenseDate),
+                        "MSC", new AddUserForm.Diploma("MSC", mscDate)
+                ))
+                .build();
+        final MockHttpServletRequestBuilder mockHttpServletRequestBuilder = MockMvcRequestBuilders.post(POST_FORM_URL)
+                .with(MockMvcRequestBuilderUtils.form(addUserForm));
+        final MockHttpServletRequest request = mockHttpServletRequestBuilder.buildRequest(servletContext);
+        mockHttpServletRequestBuilder.postProcessRequest(request);
+
+        RequestParametersAssert.assertThat(request)
+                .containsParameters(Map.of(
+                        "diplomasMap[License].name", addUserForm.getDiplomasMap().get("License").getName(),
+                        "diplomasMap[License].date", addUserForm.getDiplomasMap().get("License").getDate().format(DateTimeFormatter.ISO_DATE),
+                        "diplomasMap[MSC].name", addUserForm.getDiplomasMap().get("MSC").getName(),
+                        "diplomasMap[MSC].date", addUserForm.getDiplomasMap().get("MSC").getDate().format(DateTimeFormatter.ISO_DATE)
+                ));
+    }
+
+    @Test
+    void withParamsBigDecimal() {
+        final AddUserForm addUserForm = AddUserForm.builder()
+                .identificationNumber(BigDecimal.TEN)
+                .build();
+        final MockHttpServletRequestBuilder mockHttpServletRequestBuilder = MockMvcRequestBuilders.post(POST_FORM_URL)
+                .with(MockMvcRequestBuilderUtils.form(addUserForm));
+        final MockHttpServletRequest request = mockHttpServletRequestBuilder.buildRequest(servletContext);
+        mockHttpServletRequestBuilder.postProcessRequest(request);
+
+        assertThat(request.getParameter("identificationNumber")).isEqualTo("10");
+    }
+
+    @Test
+    void withParamsBigInteger() {
+        final AddUserForm addUserForm = AddUserForm.builder()
+                .identificationNumberBigInt(BigInteger.TEN)
+                .build();
+        final MockHttpServletRequestBuilder mockHttpServletRequestBuilder = MockMvcRequestBuilders.post(POST_FORM_URL)
+                .with(MockMvcRequestBuilderUtils.form(addUserForm));
+        final MockHttpServletRequest request = mockHttpServletRequestBuilder.buildRequest(servletContext);
+        mockHttpServletRequestBuilder.postProcessRequest(request);
+
+        assertThat(request.getParameter("identificationNumberBigInt")).isEqualTo("10");
+    }
+
+    @Test
+    void withParamsRegisterPropertyEditor() {
+        // Registering a property editor should override default conversion strategy
+        final PropertyEditorSupport bigIntegerPropertyEditor = new PropertyEditorSupport() {
+            @Override
+            public String getAsText() {
+                return "textValue";
+            }
+        };
+
+        final AddUserForm addUserForm = AddUserForm.builder()
+                .identificationNumberBigInt(BigInteger.TEN)
+                .build();
+        final Configuration config = Configuration.builder()
+                .withPropertyEditor(bigIntegerPropertyEditor, BigInteger.class)
+                .build();
+        final MockHttpServletRequestBuilder mockHttpServletRequestBuilder = MockMvcRequestBuilders.post(POST_FORM_URL)
+                .with(MockMvcRequestBuilderUtils.form(addUserForm, config));
+
+        final MockHttpServletRequest request = mockHttpServletRequestBuilder.buildRequest(servletContext);
+        mockHttpServletRequestBuilder.postProcessRequest(request);
+
+        assertThat(request.getParameter("identificationNumberBigInt")).isEqualTo("textValue");
+    }
+
+    @Test
+    void logsEveryFieldAddedToHttpRequest() {
+        final int numberOfFormFields = 32;
+        final AddUserForm addUserForm = TestFixtures.aCompleteAddUserForm();
+
+        final MockHttpServletRequestBuilder mockHttpServletRequestBuilder = MockMvcRequestBuilders.post(POST_FORM_URL)
+                .with(MockMvcRequestBuilderUtils.form(addUserForm));
+
+        mockHttpServletRequestBuilder.postProcessRequest(mockHttpServletRequestBuilder.buildRequest(servletContext));
+
+        assertThat(LOG_CAPTOR.getTraceLogs())
+                .allMatch(logLine -> logLine.matches("Adding form field \\(\\w.*=\\w.*\\) to HTTP request parameters"))
+                .hasSize(numberOfFormFields);
+    }
+}

--- a/spring-mvc-test-utils/src/test/java/io/florianlopes/spring/test/web/servlet/request/FormRequestPostProcessorTests.java
+++ b/spring-mvc-test-utils/src/test/java/io/florianlopes/spring/test/web/servlet/request/FormRequestPostProcessorTests.java
@@ -34,6 +34,7 @@ class FormRequestPostProcessorTests {
     @BeforeEach
     void setUp() {
         this.servletContext = new MockServletContext();
+        LOG_CAPTOR.clearLogs();
     }
 
     @Test
@@ -264,7 +265,7 @@ class FormRequestPostProcessorTests {
 
     @Test
     void logsEveryFieldAddedToHttpRequest() {
-        final int numberOfFormFields = 32;
+        final int numberOfFormFields = 36;
         final AddUserForm addUserForm = TestFixtures.aCompleteAddUserForm();
 
         final MockHttpServletRequestBuilder mockHttpServletRequestBuilder = MockMvcRequestBuilders.post(POST_FORM_URL)

--- a/spring-mvc-test-utils/src/test/java/io/florianlopes/spring/test/web/servlet/request/MockMvcRequestBuilderUtilsTests.java
+++ b/spring-mvc-test-utils/src/test/java/io/florianlopes/spring/test/web/servlet/request/MockMvcRequestBuilderUtilsTests.java
@@ -462,7 +462,7 @@ public class MockMvcRequestBuilderUtilsTests {
             }
 
             @Test
-            public void excludesTransientFields() {
+            void excludesTransientFields() {
                 final ConfigurationForm form = new ConfigurationForm();
                 form.setTransientName("transientName");
 
@@ -473,7 +473,7 @@ public class MockMvcRequestBuilderUtilsTests {
             }
 
             @Test
-            public void excludesStaticFields() {
+            void excludesStaticFields() {
                 final ConfigurationForm form = new ConfigurationForm();
 
                 final MockHttpServletRequestBuilder mockHttpServletRequestBuilder = MockMvcRequestBuilderUtils.postForm(POST_FORM_URL, form);

--- a/spring-mvc-test-utils/src/test/java/io/florianlopes/spring/test/web/servlet/request/MockMvcRequestBuilderUtilsTests.java
+++ b/spring-mvc-test-utils/src/test/java/io/florianlopes/spring/test/web/servlet/request/MockMvcRequestBuilderUtilsTests.java
@@ -37,6 +37,7 @@ public class MockMvcRequestBuilderUtilsTests {
     @BeforeEach
     void setUp() {
         this.servletContext = new MockServletContext();
+        LOG_CAPTOR.clearLogs();
     }
 
     @Test
@@ -283,7 +284,7 @@ public class MockMvcRequestBuilderUtilsTests {
 
     @Test
     void logsEveryFieldAddedToHttpRequest() {
-        final int numberOfFormFields = 32;
+        final int numberOfFormFields = 36;
         final AddUserForm addUserForm = TestFixtures.aCompleteAddUserForm();
 
         MockMvcRequestBuilderUtils.postForm(POST_FORM_URL, addUserForm);

--- a/spring-mvc-test-utils/src/test/java/io/florianlopes/spring/test/web/servlet/request/MockMvcRequestBuilderUtilsTests.java
+++ b/spring-mvc-test-utils/src/test/java/io/florianlopes/spring/test/web/servlet/request/MockMvcRequestBuilderUtilsTests.java
@@ -1,10 +1,12 @@
 package io.florianlopes.spring.test.web.servlet.request;
 
+import io.florianlopes.spring.test.web.servlet.request.assertion.RequestParametersAssert;
 import jakarta.servlet.ServletContext;
+import nl.altindag.log.LogCaptor;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.propertyeditors.CustomNumberEditor;
+import org.springframework.http.HttpMethod;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockServletContext;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
@@ -14,20 +16,21 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
-import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * @author Florian Lopes
  */
 public class MockMvcRequestBuilderUtilsTests {
 
+    private static final LogCaptor LOG_CAPTOR = LogCaptor.forClass(MockMvcRequestBuilderUtils.class);
+
     private static final String POST_FORM_URL = "/test";
-    private static final String DATE_FORMAT_PATTERN = "dd/MM/yyyy";
 
     private ServletContext servletContext;
 
@@ -37,199 +40,54 @@ public class MockMvcRequestBuilderUtilsTests {
     }
 
     @Test
-    void withParamsNullForm() {
-        MockHttpServletRequestBuilder mockHttpServletRequestBuilder = post(POST_FORM_URL)
-                .with(MockMvcRequestBuilderUtils.form(null));
-        final MockHttpServletRequest request = mockHttpServletRequestBuilder.buildRequest(this.servletContext);
-        mockHttpServletRequestBuilder.postProcessRequest(request);
-
-        assertThat(request.getParameterMap()).isEmpty();
-    }
-
-    @Test
-    void withParamsNullAndEmptyFields() {
-        MockHttpServletRequestBuilder mockHttpServletRequestBuilder = post(POST_FORM_URL)
-                .with(MockMvcRequestBuilderUtils.form(new AddUserForm("", "", null, null)));
-        final MockHttpServletRequest request = mockHttpServletRequestBuilder.buildRequest(this.servletContext);
-        mockHttpServletRequestBuilder.postProcessRequest(request);
-
-        assertThat(request.getParameter("name")).isEmpty();
-        assertThat(request.getParameter("firstName")).isEmpty();
-        assertThat(request.getParameter("birthDate")).isNull();
-        assertThat(request.getParameter("currentAddress.city")).isNull();
-    }
-
-    @Test
-    void withParamsSimpleFields() {
-        final AddUserForm addUserForm = AddUserForm.builder()
-                .firstName("John").name("Doe")
-                .currentAddress(new AddUserForm.Address(1, "Street", 5222, "New York"))
-                .build();
-
-        MockHttpServletRequestBuilder mockHttpServletRequestBuilder = post(POST_FORM_URL)
-                .with(MockMvcRequestBuilderUtils.form(addUserForm));
-        final MockHttpServletRequest request = mockHttpServletRequestBuilder.buildRequest(this.servletContext);
-        mockHttpServletRequestBuilder.postProcessRequest(request);
-
-        assertThat(request.getParameter("firstName")).isEqualTo("John");
-        assertThat(request.getParameter("currentAddress.city")).isEqualTo("New York");
-    }
-
-    @Test
-    void withParamsSimpleCollection() {
-        final AddUserForm addUserForm = AddUserForm.builder().firstName("John").name("Doe")
-                .usernames(Arrays.asList("john.doe", "jdoe"))
-                .build();
-
-        MockHttpServletRequestBuilder mockHttpServletRequestBuilder = post(POST_FORM_URL)
-                .with(MockMvcRequestBuilderUtils.form(addUserForm));
-        final MockHttpServletRequest request = mockHttpServletRequestBuilder.buildRequest(this.servletContext);
-        mockHttpServletRequestBuilder.postProcessRequest(request);
-
-        assertThat(request.getParameter("usernames[0]")).isEqualTo("john.doe");
-        assertThat(request.getParameter("usernames[1]")).isEqualTo("jdoe");
-    }
-
-    @Test
-    void withParamsComplexCollection() {
-        final AddUserForm addUserForm = AddUserForm.builder().firstName("John").name("Doe").build();
-        MockMvcRequestBuilderUtils.registerPropertyEditor(LocalDate.class, new CustomLocalDatePropertyEditor(DATE_FORMAT_PATTERN));
-        final LocalDate bachelorDate = LocalDate.now().minusYears(2);
-        final LocalDate masterDate = LocalDate.now();
-        addUserForm.setDiplomas(Arrays.asList(new AddUserForm.Diploma("License", bachelorDate), new AddUserForm.Diploma("MSC", masterDate)));
-
-        MockHttpServletRequestBuilder mockHttpServletRequestBuilder = post(POST_FORM_URL)
-                .with(MockMvcRequestBuilderUtils.form(addUserForm));
-        MockHttpServletRequest request = mockHttpServletRequestBuilder.buildRequest(this.servletContext);
-        mockHttpServletRequestBuilder.postProcessRequest(request);
-
-        assertThat(request.getParameter("diplomas[0].name")).isEqualTo("License");
-        assertThat(request.getParameter("diplomas[0].date")).isEqualTo(bachelorDate.format(DateTimeFormatter.ofPattern(DATE_FORMAT_PATTERN)));
-        assertThat(request.getParameter("diplomas[1].name")).isEqualTo("MSC");
-        assertThat(request.getParameter("diplomas[1].date")).isEqualTo(masterDate.format(DateTimeFormatter.ofPattern(DATE_FORMAT_PATTERN)));
-    }
-
-    @Test
-    void withParamsSimpleArray() {
-        final AddUserForm addUserForm = AddUserForm.builder().firstName("John").name("Doe")
-                .usernamesArray(new String[]{"john.doe", "jdoe"})
-                .build();
-        MockHttpServletRequestBuilder mockHttpServletRequestBuilder = post(POST_FORM_URL)
-                .with(MockMvcRequestBuilderUtils.form(addUserForm));
-        MockHttpServletRequest request = mockHttpServletRequestBuilder.buildRequest(this.servletContext);
-        mockHttpServletRequestBuilder.postProcessRequest(request);
-
-        assertThat(request.getParameter("usernamesArray[0]")).isEqualTo("john.doe");
-        assertThat(request.getParameter("usernamesArray[1]")).isEqualTo("jdoe");
-    }
-
-    @Test
-    void withParamsComplexArray() {
-        final AddUserForm addUserForm = AddUserForm.builder().firstName("John").name("Doe")
-                .usernames(Arrays.asList("john.doe", "jdoe"))
-                .formerAddresses(new AddUserForm.Address[]{
-                        new AddUserForm.Address(10, "Street", 5222, "Chicago"),
-                        new AddUserForm.Address(20, "Street", 5222, "Washington")
-                })
-                .build();
-        MockHttpServletRequestBuilder mockHttpServletRequestBuilder = post(POST_FORM_URL)
-                .with(MockMvcRequestBuilderUtils.form(addUserForm));
-        MockHttpServletRequest request = mockHttpServletRequestBuilder.buildRequest(this.servletContext);
-        mockHttpServletRequestBuilder.postProcessRequest(request);
-
-        assertThat(request.getParameter("usernames[0]")).isEqualTo("john.doe");
-        assertThat(request.getParameter("usernames[1]")).isEqualTo("jdoe");
-    }
-
-    @Test
-    void withParamsEnumField() {
-        final AddUserForm addUserForm = AddUserForm.builder()
-                .firstName("John").name("Doe").gender(AddUserForm.Gender.MALE)
-                .build();
-        MockHttpServletRequestBuilder mockHttpServletRequestBuilder = post(POST_FORM_URL)
-                .with(MockMvcRequestBuilderUtils.form(addUserForm));
-        MockHttpServletRequest request = mockHttpServletRequestBuilder.buildRequest(this.servletContext);
-        mockHttpServletRequestBuilder.postProcessRequest(request);
-
-        assertThat(request.getParameter("gender")).isEqualTo("MALE");
-    }
-
-    @Test
-    void withParamsSimpleMapField() {
-        final Map<String, String> metadatas = new HashMap<>();
-        metadatas.put("firstName", "John");
-        metadatas.put("name", "Doe");
-        metadatas.put("gender", null);
-        final AddUserForm addUserForm = AddUserForm.builder()
-                .metadatas(metadatas)
-                .build();
-        MockHttpServletRequestBuilder mockHttpServletRequestBuilder = post(POST_FORM_URL)
-                .with(MockMvcRequestBuilderUtils.form(addUserForm));
-        MockHttpServletRequest request = mockHttpServletRequestBuilder.buildRequest(this.servletContext);
-        mockHttpServletRequestBuilder.postProcessRequest(request);
-
-        assertThat(request.getParameter("metadatas[firstName]")).isEqualTo("John");
-        assertThat(request.getParameter("metadatas[name]")).isEqualTo("Doe");
-        assertThat(request.getParameter("metadatas[gender]")).isEmpty();
-    }
-
-    @Test
-    void withParamsBigDecimal() {
-        final AddUserForm addUserForm = AddUserForm.builder()
-                .identificationNumber(BigDecimal.TEN)
-                .build();
-        MockHttpServletRequestBuilder mockHttpServletRequestBuilder = post(POST_FORM_URL)
-                .with(MockMvcRequestBuilderUtils.form(addUserForm));
-        MockHttpServletRequest request = mockHttpServletRequestBuilder.buildRequest(this.servletContext);
-        mockHttpServletRequestBuilder.postProcessRequest(request);
-
-        assertThat(request.getParameter("identificationNumber")).isEqualTo("10");
-    }
-
-    @Test
-    void withParamsBigInteger() {
-        final AddUserForm addUserForm = AddUserForm.builder()
-                .identificationNumberBigInt(BigInteger.TEN)
-                .build();
-        MockHttpServletRequestBuilder mockHttpServletRequestBuilder = post(POST_FORM_URL)
-                .with(MockMvcRequestBuilderUtils.form(addUserForm));
-        MockHttpServletRequest request = mockHttpServletRequestBuilder.buildRequest(this.servletContext);
-        mockHttpServletRequestBuilder.postProcessRequest(request);
-
-        assertThat(request.getParameter("identificationNumberBigInt")).isEqualTo("10");
-    }
-
-    @Test
-    void withParamsRegisterPropertyEditor() {
-        try {
-            // Registering a property editor should override default conversion strategy
-            MockMvcRequestBuilderUtils.registerPropertyEditor(BigInteger.class, new PropertyEditorSupport() {
-                @Override
-                public String getAsText() {
-                    return "textValue";
-                }
-            });
-
-            final AddUserForm build = AddUserForm.builder().identificationNumberBigInt(BigInteger.TEN).build();
-            MockHttpServletRequestBuilder mockHttpServletRequestBuilder = post(POST_FORM_URL)
-                    .with(MockMvcRequestBuilderUtils.form(build));
-            MockHttpServletRequest request = mockHttpServletRequestBuilder.buildRequest(this.servletContext);
-            mockHttpServletRequestBuilder.postProcessRequest(request);
-
-            assertThat(request.getParameter("identificationNumberBigInt")).isEqualTo("textValue");
-        } finally {
-            // Restore original property editor
-            MockMvcRequestBuilderUtils.registerPropertyEditor(BigInteger.class, new CustomNumberEditor(BigInteger.class, true));
-        }
-    }
-
-    @Test
     void correctUrl() {
-        final MockHttpServletRequestBuilder mockHttpServletRequestBuilder = MockMvcRequestBuilderUtils.postForm(POST_FORM_URL,
-                new AddUserForm("John", "Doe", null, null));
+        final MockHttpServletRequestBuilder mockHttpServletRequestBuilder =
+                MockMvcRequestBuilderUtils.postForm(POST_FORM_URL, new AddUserForm());
         final MockHttpServletRequest request = mockHttpServletRequestBuilder.buildRequest(this.servletContext);
 
         assertThat(request.getPathInfo()).isEqualTo(POST_FORM_URL);
+    }
+
+    @Test
+    void nullUrlThrowsIllegalArgumentException() {
+        assertThrows(IllegalArgumentException.class, () -> MockMvcRequestBuilderUtils.postForm(null, new AddUserForm()));
+    }
+
+    @Test
+    void postHttpMethod() {
+        final MockHttpServletRequestBuilder mockHttpServletRequestBuilder =
+                MockMvcRequestBuilderUtils.postForm(POST_FORM_URL, new AddUserForm());
+        final MockHttpServletRequest httpServletRequest = mockHttpServletRequestBuilder.buildRequest(this.servletContext);
+
+        assertThat(httpServletRequest.getMethod()).isEqualTo(HttpMethod.POST.name());
+    }
+
+    @Test
+    void postHttpMethodWithConfig() {
+        final MockHttpServletRequestBuilder mockHttpServletRequestBuilder =
+                MockMvcRequestBuilderUtils.postForm(POST_FORM_URL, new AddUserForm(), Configuration.INCLUDE_STATIC);
+        final MockHttpServletRequest httpServletRequest = mockHttpServletRequestBuilder.buildRequest(this.servletContext);
+
+        assertThat(httpServletRequest.getMethod()).isEqualTo(HttpMethod.POST.name());
+    }
+
+    @Test
+    void putHttpMethod() {
+        final MockHttpServletRequestBuilder mockHttpServletRequestBuilder =
+                MockMvcRequestBuilderUtils.putForm(POST_FORM_URL, new AddUserForm());
+        final MockHttpServletRequest httpServletRequest = mockHttpServletRequestBuilder.buildRequest(this.servletContext);
+
+        assertThat(httpServletRequest.getMethod()).isEqualTo(HttpMethod.PUT.name());
+    }
+
+
+    @Test
+    void putHttpMethodWithConfig() {
+        final MockHttpServletRequestBuilder mockHttpServletRequestBuilder =
+                MockMvcRequestBuilderUtils.putForm(POST_FORM_URL, new AddUserForm(), Configuration.INCLUDE_STATIC);
+        final MockHttpServletRequest httpServletRequest = mockHttpServletRequestBuilder.buildRequest(this.servletContext);
+
+        assertThat(httpServletRequest.getMethod()).isEqualTo(HttpMethod.PUT.name());
     }
 
     @Test
@@ -241,34 +99,37 @@ public class MockMvcRequestBuilderUtilsTests {
     }
 
     @Test
-    void nullAndEmptyFields() {
-        final MockHttpServletRequestBuilder mockHttpServletRequestBuilder = MockMvcRequestBuilderUtils.postForm(POST_FORM_URL,
-                new AddUserForm("", "", null, null));
+    void nullFieldsAreNotAddedToRequestParameters() {
+        final AddUserForm addUserForm = AddUserForm.builder()
+                .firstName(null)
+                .birthDate(null)
+                .build();
+        final MockHttpServletRequestBuilder mockHttpServletRequestBuilder =
+                MockMvcRequestBuilderUtils.postForm(POST_FORM_URL, addUserForm);
+
         final MockHttpServletRequest request = mockHttpServletRequestBuilder.buildRequest(this.servletContext);
 
-        assertThat(request.getParameter("name")).isEmpty();
-        assertThat(request.getParameter("firstName")).isEmpty();
+        assertThat(request.getParameter("firstName")).isNull();
         assertThat(request.getParameter("birthDate")).isNull();
-        assertThat(request.getParameter("currentAddress.city")).isNull();
     }
 
     @Test
-    void simpleFields() {
+    void emptyFieldsAreAddedAsEmptyRequestParameters() {
         final AddUserForm addUserForm = AddUserForm.builder()
-                .firstName("John").name("Doe")
-                .currentAddress(new AddUserForm.Address(1, "Street", 5222, "New York"))
+                .firstName("")
                 .build();
-        final MockHttpServletRequestBuilder mockHttpServletRequestBuilder = MockMvcRequestBuilderUtils.postForm(POST_FORM_URL, addUserForm);
+        final MockHttpServletRequestBuilder mockHttpServletRequestBuilder =
+                MockMvcRequestBuilderUtils.postForm(POST_FORM_URL, addUserForm);
+
         final MockHttpServletRequest request = mockHttpServletRequestBuilder.buildRequest(this.servletContext);
 
-        assertThat(request.getParameter("firstName")).isEqualTo("John");
-        assertThat(request.getParameter("currentAddress.city")).isEqualTo("New York");
+        assertThat(request.getParameter("firstName")).isEmpty();
     }
 
     @Test
     void simpleCollection() {
-        final AddUserForm addUserForm = AddUserForm.builder().firstName("John").name("Doe")
-                .usernames(Arrays.asList("john.doe", "jdoe"))
+        final AddUserForm addUserForm = AddUserForm.builder()
+                .usernames(List.of("john.doe", "jdoe"))
                 .build();
         final MockHttpServletRequestBuilder mockHttpServletRequestBuilder = MockMvcRequestBuilderUtils.postForm(POST_FORM_URL, addUserForm);
         final MockHttpServletRequest request = mockHttpServletRequestBuilder.buildRequest(this.servletContext);
@@ -279,23 +140,30 @@ public class MockMvcRequestBuilderUtilsTests {
 
     @Test
     void complexCollections() {
-        final AddUserForm addUserForm = AddUserForm.builder().firstName("John").name("Doe").build();
-        MockMvcRequestBuilderUtils.registerPropertyEditor(LocalDate.class, new CustomLocalDatePropertyEditor(DATE_FORMAT_PATTERN));
         final LocalDate bachelorDate = LocalDate.now().minusYears(2);
         final LocalDate masterDate = LocalDate.now();
-        addUserForm.setDiplomas(Arrays.asList(new AddUserForm.Diploma("License", bachelorDate), new AddUserForm.Diploma("MSC", masterDate)));
-        final MockHttpServletRequestBuilder mockHttpServletRequestBuilder = MockMvcRequestBuilderUtils.postForm(POST_FORM_URL, addUserForm);
+        final AddUserForm addUserForm = AddUserForm.builder()
+                .diplomas(List.of(
+                        new AddUserForm.Diploma("License", bachelorDate),
+                        new AddUserForm.Diploma("MSC", masterDate)
+                ))
+                .build();
+        final MockHttpServletRequestBuilder mockHttpServletRequestBuilder =
+                MockMvcRequestBuilderUtils.postForm(POST_FORM_URL, addUserForm);
 
-        MockHttpServletRequest request = mockHttpServletRequestBuilder.buildRequest(this.servletContext);
-        assertThat(request.getParameter("diplomas[0].name")).isEqualTo("License");
-        assertThat(request.getParameter("diplomas[0].date")).isEqualTo(bachelorDate.format(DateTimeFormatter.ofPattern(DATE_FORMAT_PATTERN)));
-        assertThat(request.getParameter("diplomas[1].name")).isEqualTo("MSC");
-        assertThat(request.getParameter("diplomas[1].date")).isEqualTo(masterDate.format(DateTimeFormatter.ofPattern(DATE_FORMAT_PATTERN)));
+        final MockHttpServletRequest request = mockHttpServletRequestBuilder.buildRequest(this.servletContext);
+        RequestParametersAssert.assertThat(request)
+                .containsParameters(Map.of(
+                        "diplomas[0].name", addUserForm.getDiplomas().get(0).getName(),
+                        "diplomas[0].date", addUserForm.getDiplomas().get(0).getDate().format(DateTimeFormatter.ISO_DATE),
+                        "diplomas[1].name", addUserForm.getDiplomas().get(1).getName(),
+                        "diplomas[1].date", addUserForm.getDiplomas().get(1).getDate().format(DateTimeFormatter.ISO_DATE)
+                ));
     }
 
     @Test
     void simpleArray() {
-        final AddUserForm addUserForm = AddUserForm.builder().firstName("John").name("Doe")
+        final AddUserForm addUserForm = AddUserForm.builder()
                 .usernamesArray(new String[]{"john.doe", "jdoe"})
                 .build();
         final MockHttpServletRequestBuilder mockHttpServletRequestBuilder = MockMvcRequestBuilderUtils.postForm(POST_FORM_URL, addUserForm);
@@ -307,8 +175,7 @@ public class MockMvcRequestBuilderUtilsTests {
 
     @Test
     void complexArray() {
-        final AddUserForm addUserForm = AddUserForm.builder().firstName("John").name("Doe")
-                .usernames(Arrays.asList("john.doe", "jdoe"))
+        final AddUserForm addUserForm = AddUserForm.builder()
                 .formerAddresses(new AddUserForm.Address[]{
                         new AddUserForm.Address(10, "Street", 5222, "Chicago"),
                         new AddUserForm.Address(20, "Street", 5222, "Washington")
@@ -317,14 +184,23 @@ public class MockMvcRequestBuilderUtilsTests {
         final MockHttpServletRequestBuilder mockHttpServletRequestBuilder = MockMvcRequestBuilderUtils.postForm(POST_FORM_URL, addUserForm);
         final MockHttpServletRequest request = mockHttpServletRequestBuilder.buildRequest(this.servletContext);
 
-        assertThat(request.getParameter("usernames[0]")).isEqualTo("john.doe");
-        assertThat(request.getParameter("usernames[1]")).isEqualTo("jdoe");
+        RequestParametersAssert.assertThat(request)
+                .containsParameters(Map.of(
+                        "formerAddresses[0].city", addUserForm.getFormerAddresses()[0].getCity(),
+                        "formerAddresses[1].city", addUserForm.getFormerAddresses()[1].getCity(),
+                        "formerAddresses[0].streetName", addUserForm.getFormerAddresses()[0].getStreetName(),
+                        "formerAddresses[1].streetName", addUserForm.getFormerAddresses()[1].getStreetName(),
+                        "formerAddresses[0].streetNumber", String.valueOf(addUserForm.getFormerAddresses()[0].getStreetNumber()),
+                        "formerAddresses[1].streetNumber", String.valueOf(addUserForm.getFormerAddresses()[1].getStreetNumber()),
+                        "formerAddresses[0].postalCode", String.valueOf(addUserForm.getFormerAddresses()[0].getPostalCode()),
+                        "formerAddresses[1].postalCode", String.valueOf(addUserForm.getFormerAddresses()[1].getPostalCode())
+                ));
     }
 
     @Test
     void enumField() {
         final AddUserForm addUserForm = AddUserForm.builder()
-                .firstName("John").name("Doe").gender(AddUserForm.Gender.MALE)
+                .gender(AddUserForm.Gender.MALE)
                 .build();
         final MockHttpServletRequestBuilder mockHttpServletRequestBuilder = MockMvcRequestBuilderUtils.postForm(POST_FORM_URL, addUserForm);
         final MockHttpServletRequest request = mockHttpServletRequestBuilder.buildRequest(this.servletContext);
@@ -346,7 +222,41 @@ public class MockMvcRequestBuilderUtilsTests {
 
         assertThat(request.getParameter("metadatas[firstName]")).isEqualTo("John");
         assertThat(request.getParameter("metadatas[name]")).isEqualTo("Doe");
+    }
+
+    @Test
+    void simpleMapFieldsWithNullValueAreAddedAsEmptyRequestParameters() {
+        final Map<String, String> metadatas = new HashMap<>();
+        metadatas.put("gender", null);
+        final AddUserForm addUserForm = AddUserForm.builder()
+                .metadatas(metadatas)
+                .build();
+        final MockHttpServletRequestBuilder mockHttpServletRequestBuilder = MockMvcRequestBuilderUtils.postForm(POST_FORM_URL, addUserForm);
+        final MockHttpServletRequest request = mockHttpServletRequestBuilder.buildRequest(this.servletContext);
+
         assertThat(request.getParameter("metadatas[gender]")).isEmpty();
+    }
+
+    @Test
+    void complexMapField() {
+        final LocalDate mscDate = LocalDate.now();
+        final LocalDate licenseDate = LocalDate.now().minusYears(2);
+        final AddUserForm addUserForm = AddUserForm.builder()
+                .diplomasMap(Map.of(
+                        "License", new AddUserForm.Diploma("License", licenseDate),
+                        "MSC", new AddUserForm.Diploma("MSC", mscDate)
+                ))
+                .build();
+        final MockHttpServletRequestBuilder mockHttpServletRequestBuilder = MockMvcRequestBuilderUtils.postForm(POST_FORM_URL, addUserForm);
+        final MockHttpServletRequest request = mockHttpServletRequestBuilder.buildRequest(this.servletContext);
+
+        RequestParametersAssert.assertThat(request)
+                .containsParameters(Map.of(
+                        "diplomasMap[License].name", addUserForm.getDiplomasMap().get("License").getName(),
+                        "diplomasMap[License].date", addUserForm.getDiplomasMap().get("License").getDate().format(DateTimeFormatter.ISO_DATE),
+                        "diplomasMap[MSC].name", addUserForm.getDiplomasMap().get("MSC").getName(),
+                        "diplomasMap[MSC].date", addUserForm.getDiplomasMap().get("MSC").getDate().format(DateTimeFormatter.ISO_DATE)
+                ));
     }
 
     @Test
@@ -372,50 +282,22 @@ public class MockMvcRequestBuilderUtilsTests {
     }
 
     @Test
-    void registerPropertyEditor() {
-        try {
-            // Registering a property editor should override default conversion strategy
-            MockMvcRequestBuilderUtils.registerPropertyEditor(BigInteger.class, new PropertyEditorSupport() {
-                @Override
-                public String getAsText() {
-                    return "textValue";
-                }
-            });
+    void logsEveryFieldAddedToHttpRequest() {
+        final int numberOfFormFields = 32;
+        final AddUserForm addUserForm = TestFixtures.aCompleteAddUserForm();
 
-            final AddUserForm build = AddUserForm.builder().identificationNumberBigInt(BigInteger.TEN).build();
-            final MockHttpServletRequestBuilder mockHttpServletRequestBuilder = MockMvcRequestBuilderUtils.postForm(POST_FORM_URL, build);
+        MockMvcRequestBuilderUtils.postForm(POST_FORM_URL, addUserForm);
 
-            MockHttpServletRequest request = mockHttpServletRequestBuilder.buildRequest(this.servletContext);
-            assertThat(request.getParameter("identificationNumberBigInt")).isEqualTo("textValue");
-        } finally {
-            // Restore original property editor
-            MockMvcRequestBuilderUtils.registerPropertyEditor(BigInteger.class, new CustomNumberEditor(BigInteger.class, true));
-        }
-    }
-
-    @Test
-    void postMethod() {
-        final MockHttpServletRequestBuilder mockHttpServletRequestBuilder = MockMvcRequestBuilderUtils.postForm(POST_FORM_URL,
-                new AddUserForm("John", "Doe", null, null));
-        final MockHttpServletRequest request = mockHttpServletRequestBuilder.buildRequest(this.servletContext);
-
-        assertThat(request.getMethod()).isEqualTo("POST");
-    }
-
-    @Test
-    void putMethod() {
-        final MockHttpServletRequestBuilder mockHttpServletRequestBuilder = MockMvcRequestBuilderUtils.putForm(POST_FORM_URL,
-                new AddUserForm("John", "Doe", null, null));
-        final MockHttpServletRequest request = mockHttpServletRequestBuilder.buildRequest(this.servletContext);
-
-        assertThat(request.getMethod()).isEqualTo("PUT");
+        assertThat(LOG_CAPTOR.getTraceLogs())
+                .allMatch(logLine -> logLine.matches("Adding form field \\(\\w.*=\\w.*\\) to HTTP request parameters"))
+                .hasSize(numberOfFormFields);
     }
 
     @Nested
-    class ConfigurationTest {
+    class ConfigurationTests {
 
         @Test
-        void testDefaultConfig() {
+        void defaultConfig() {
             final ConfigurationForm form = new ConfigurationForm();
             form.setName("name");
             form.setTransientName("transientName");
@@ -431,7 +313,7 @@ public class MockMvcRequestBuilderUtilsTests {
         }
 
         @Test
-        void testExcludeFinalField() {
+        void excludeFinalField() {
             final ConfigurationForm form = new ConfigurationForm();
             form.setName("name");
             form.setTransientName("transientName");
@@ -439,13 +321,13 @@ public class MockMvcRequestBuilderUtilsTests {
             final MockHttpServletRequestBuilder mockHttpServletRequestBuilder = MockMvcRequestBuilderUtils.postForm(POST_FORM_URL, form, Configuration.EXCLUDE_FINAL);
             final MockHttpServletRequest request = mockHttpServletRequestBuilder.buildRequest(servletContext);
 
-            assertThat(request.getParameterMap()).hasSize(2);
+            assertThat(request.getParameterMap()).hasSize(1);
             assertThat(request.getParameter("name")).isEqualTo("name");
-            assertThat(request.getParameter("transientName")).isEqualTo("transientName");
+            assertThat(request.getParameter("transientName")).isNull();
         }
 
         @Test
-        void testIncludeTransientField() {
+        void includeTransientField() {
             final ConfigurationForm form = new ConfigurationForm();
             form.setName("name");
             form.setTransientName("transientName");
@@ -459,7 +341,7 @@ public class MockMvcRequestBuilderUtilsTests {
         }
 
         @Test
-        void testIncludeStaticField() {
+        void includeStaticField() {
             final ConfigurationForm form = new ConfigurationForm();
             form.setName("name");
             form.setTransientName("transientName");
@@ -473,22 +355,28 @@ public class MockMvcRequestBuilderUtilsTests {
         }
 
         @Test
-        void testCustomPredicate() {
-            final Configuration config = Configuration.builder().fieldPredicate(field -> "transientName".equals(field.getName())).build();
+        void customPredicate() {
+            final Configuration config = Configuration.builder()
+                    .fieldPredicate(field -> "simpleField".equals(field.getName()))
+                    .build();
 
             final ConfigurationForm form = new ConfigurationForm();
             form.setName("name");
-            form.setTransientName("transientName");
+            form.setSimpleField("simpleValue");
 
             final MockHttpServletRequestBuilder mockHttpServletRequestBuilder = MockMvcRequestBuilderUtils.postForm(POST_FORM_URL, form, config);
             final MockHttpServletRequest request = mockHttpServletRequestBuilder.buildRequest(servletContext);
 
-            assertThat(request.getParameterMap()).isEmpty();
+            assertThat(request.getParameterMap())
+                    .containsExactly(Map.entry("simpleField", new String[]{form.getSimpleField()}));
         }
 
         @Test
-        void testCustomPredicateWithModifier() {
-            final Configuration config = Configuration.builder().includeTransient(true).fieldPredicate(field -> "transientName".equals(field.getName())).build();
+        void customPredicateWithModifier() {
+            final Configuration config = Configuration.builder()
+                    .includeTransient(true)
+                    .fieldPredicate(field -> "transientName".equals(field.getName()))
+                    .build();
 
             final ConfigurationForm form = new ConfigurationForm();
             form.setName("name");
@@ -501,6 +389,99 @@ public class MockMvcRequestBuilderUtilsTests {
             assertThat(request.getParameter("transientName")).isEqualTo("transientName");
         }
 
+        @Test
+        void customPropertyEditor() {
+            // Registering a property editor should override default conversion strategy
+            final PropertyEditorSupport propertyEditor = new PropertyEditorSupport() {
+                @Override
+                public String getAsText() {
+                    return "textValue";
+                }
+            };
+
+            final AddUserForm addUserForm = AddUserForm
+                    .builder()
+                    .identificationNumberBigInt(BigInteger.TEN)
+                    .build();
+            final Configuration config = Configuration
+                    .builder()
+                    .withPropertyEditor(propertyEditor, BigInteger.class)
+                    .build();
+            final MockHttpServletRequestBuilder mockHttpServletRequestBuilder =
+                    MockMvcRequestBuilderUtils.postForm(POST_FORM_URL, addUserForm, config);
+
+            final MockHttpServletRequest request = mockHttpServletRequestBuilder.buildRequest(servletContext);
+            assertThat(request.getParameter("identificationNumberBigInt")).isEqualTo("textValue");
+        }
+
+        @Test
+        void registerMultiplePropertyEditors() {
+            // Registering a property editor should override default conversion strategy
+            final PropertyEditorSupport propertyEditor = new PropertyEditorSupport() {
+                @Override
+                public String getAsText() {
+                    return "textValue";
+                }
+            };
+            final PropertyEditorSupport customDatePropertyEditor = new PropertyEditorSupport() {
+                @Override
+                public String getAsText() {
+                    return "textDateValue";
+                }
+            };
+
+            final AddUserForm addUserForm = AddUserForm
+                    .builder()
+                    .identificationNumberBigInt(BigInteger.TEN)
+                    .birthDate(LocalDate.now().minusYears(2))
+                    .build();
+            final Configuration config = Configuration
+                    .builder()
+                    .withPropertyEditor(propertyEditor, BigInteger.class)
+                    .withPropertyEditor(customDatePropertyEditor, LocalDate.class)
+                    .build();
+            final MockHttpServletRequestBuilder mockHttpServletRequestBuilder =
+                    MockMvcRequestBuilderUtils.postForm(POST_FORM_URL, addUserForm, config);
+
+            final MockHttpServletRequest request = mockHttpServletRequestBuilder.buildRequest(servletContext);
+            assertThat(request.getParameter("identificationNumberBigInt")).isEqualTo("textValue");
+            assertThat(request.getParameter("birthDate")).isEqualTo("textDateValue");
+        }
+
+        @Nested
+        class DefaultConfiguration {
+
+            @Test
+            void includesFinalFields() {
+                final ConfigurationForm form = new ConfigurationForm();
+
+                final MockHttpServletRequestBuilder mockHttpServletRequestBuilder = MockMvcRequestBuilderUtils.postForm(POST_FORM_URL, form);
+                final MockHttpServletRequest request = mockHttpServletRequestBuilder.buildRequest(servletContext);
+
+                assertThat(request.getParameter("finalName")).isEqualTo("finalValue");
+            }
+
+            @Test
+            public void excludesTransientFields() {
+                final ConfigurationForm form = new ConfigurationForm();
+                form.setTransientName("transientName");
+
+                final MockHttpServletRequestBuilder mockHttpServletRequestBuilder = MockMvcRequestBuilderUtils.postForm(POST_FORM_URL, form);
+                final MockHttpServletRequest request = mockHttpServletRequestBuilder.buildRequest(servletContext);
+
+                assertThat(request.getParameter("transientName")).isNullOrEmpty();
+            }
+
+            @Test
+            public void excludesStaticFields() {
+                final ConfigurationForm form = new ConfigurationForm();
+
+                final MockHttpServletRequestBuilder mockHttpServletRequestBuilder = MockMvcRequestBuilderUtils.postForm(POST_FORM_URL, form);
+                final MockHttpServletRequest request = mockHttpServletRequestBuilder.buildRequest(servletContext);
+
+                assertThat(request.getParameter("STATIC_NAME")).isNullOrEmpty();
+            }
+        }
     }
 
 }

--- a/spring-mvc-test-utils/src/test/java/io/florianlopes/spring/test/web/servlet/request/MockMvcRequestBuilderUtilsTests.java
+++ b/spring-mvc-test-utils/src/test/java/io/florianlopes/spring/test/web/servlet/request/MockMvcRequestBuilderUtilsTests.java
@@ -416,7 +416,6 @@ public class MockMvcRequestBuilderUtilsTests {
 
         @Test
         void registerMultiplePropertyEditors() {
-            // Registering a property editor should override default conversion strategy
             final PropertyEditorSupport propertyEditor = new PropertyEditorSupport() {
                 @Override
                 public String getAsText() {

--- a/spring-mvc-test-utils/src/test/java/io/florianlopes/spring/test/web/servlet/request/TestFixtures.java
+++ b/spring-mvc-test-utils/src/test/java/io/florianlopes/spring/test/web/servlet/request/TestFixtures.java
@@ -12,6 +12,8 @@ public class TestFixtures {
     }
 
     static AddUserForm aCompleteAddUserForm() {
+        final LocalDate licenseDate = LocalDate.of(2021, 9, 4);
+        final LocalDate mscDate = LocalDate.of(2024, 9, 4);
         return AddUserForm.builder()
                 .firstName("John").name("Doe")
                 .gender(AddUserForm.Gender.MALE)
@@ -27,8 +29,12 @@ public class TestFixtures {
                         new AddUserForm.Address(20, "Street", 5222, "Washington")
                 })
                 .diplomas(List.of(
-                        new AddUserForm.Diploma("License", LocalDate.of(2021, 9, 4)),
-                        new AddUserForm.Diploma("MSC", LocalDate.of(2024, 9, 4))
+                        new AddUserForm.Diploma("License", licenseDate),
+                        new AddUserForm.Diploma("MSC", mscDate)
+                ))
+                .diplomasMap(Map.of(
+                        "License", new AddUserForm.Diploma("License", licenseDate),
+                        "MSC", new AddUserForm.Diploma("MSC", mscDate)
                 ))
                 .build();
     }

--- a/spring-mvc-test-utils/src/test/java/io/florianlopes/spring/test/web/servlet/request/TestFixtures.java
+++ b/spring-mvc-test-utils/src/test/java/io/florianlopes/spring/test/web/servlet/request/TestFixtures.java
@@ -1,0 +1,43 @@
+package io.florianlopes.spring.test.web.servlet.request;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+
+public class TestFixtures {
+
+    private TestFixtures() {
+    }
+
+    static AddUserForm aCompleteAddUserForm() {
+        return AddUserForm.builder()
+                .firstName("John").name("Doe")
+                .gender(AddUserForm.Gender.MALE)
+                .identificationNumber(BigDecimal.ONE)
+                .identificationNumberBigInt(BigInteger.ONE)
+                .metadatas(Map.of("firstName", "John", "name", "Doe"))
+                .birthDate(LocalDate.of(2016, 8, 29))
+                .currentAddress(anAddress().withLinkedAddress(aLinkedAddress()))
+                .usernames(List.of("john.doe", "jdoe"))
+                .usernamesArray(new String[]{"john.doe", "jdoe"})
+                .formerAddresses(new AddUserForm.Address[]{
+                        new AddUserForm.Address(10, "Street", 5222, "Chicago"),
+                        new AddUserForm.Address(20, "Street", 5222, "Washington")
+                })
+                .diplomas(List.of(
+                        new AddUserForm.Diploma("License", LocalDate.of(2021, 9, 4)),
+                        new AddUserForm.Diploma("MSC", LocalDate.of(2024, 9, 4))
+                ))
+                .build();
+    }
+
+    static AddUserForm.Address aLinkedAddress() {
+        return new AddUserForm.Address(42, "Linked Street", 8888, "Linked New York");
+    }
+
+    static AddUserForm.Address anAddress() {
+        return new AddUserForm.Address(1, "Street", 5222, "New York");
+    }
+}

--- a/spring-mvc-test-utils/src/test/java/io/florianlopes/spring/test/web/servlet/request/assertion/RequestParametersAssert.java
+++ b/spring-mvc-test-utils/src/test/java/io/florianlopes/spring/test/web/servlet/request/assertion/RequestParametersAssert.java
@@ -1,0 +1,29 @@
+package io.florianlopes.spring.test.web.servlet.request.assertion;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.assertj.core.api.AbstractAssert;
+
+import java.util.Map;
+
+public class RequestParametersAssert extends AbstractAssert<RequestParametersAssert, HttpServletRequest> {
+
+    protected RequestParametersAssert(HttpServletRequest httpServletRequest) {
+        super(httpServletRequest, RequestParametersAssert.class);
+    }
+
+    public static RequestParametersAssert assertThat(HttpServletRequest httpServletRequest) {
+        return new RequestParametersAssert(httpServletRequest);
+    }
+
+    public RequestParametersAssert containsParameters(Map<String, String> parameters) {
+        isNotNull();
+
+        parameters.forEach((key, value) -> {
+            if (this.actual.getParameter(key) == null || !this.actual.getParameter(key).equals(value)) {
+                failWithMessage("http servlet request does not contain required parameters: %s", parameters);
+            }
+        });
+
+        return this;
+    }
+}


### PR DESCRIPTION
- Rewrite `MockMvcRequestBuilderUtils` to simplify and improve modularity
- Add `FormFieldWrapper` class to encapsulate form field processing logic
- Update `Configuration` class to support custom `PropertyEditor` registration
- Externalize `FormRequestPostProcessor` class for better separation of concerns
- Set log level to TRACE when adding fields to request parameters

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/f-lopes/spring-mvc-test-utils/285)
<!-- Reviewable:end -->
