### PR TITLE
chore: Upgrade Spring framework version to 6.2.8

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,5 +12,4 @@ updates:
     - 4.2.2
   - dependency-name: org.springframework:spring-test
     versions:
-    - 5.3.4
-    - 5.3.5
+    - 6.2.8

--- a/.sdkmanrc
+++ b/.sdkmanrc
@@ -1,4 +1,4 @@
 # Enable auto-env through the sdkman_auto_env config
 # Add key=value pairs of SDKs to use below
-java=17.0.7-tem
-maven=3.9.9
+java=21.0.7-tem
+maven=3.9.10

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-		<spring-framework.version>6.1.13</spring-framework.version>
+		<spring-framework.version>6.2.8</spring-framework.version>
 
 		<logback-classic.version>1.5.7</logback-classic.version>
 

--- a/spring-mvc-test-utils/src/test/java/io/florianlopes/spring/test/web/servlet/request/FormRequestPostProcessorTests.java
+++ b/spring-mvc-test-utils/src/test/java/io/florianlopes/spring/test/web/servlet/request/FormRequestPostProcessorTests.java
@@ -4,7 +4,6 @@ import io.florianlopes.spring.test.web.servlet.request.assertion.RequestParamete
 import jakarta.servlet.ServletContext;
 import nl.altindag.log.LogCaptor;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockServletContext;
@@ -22,7 +21,6 @@ import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@Nested
 class FormRequestPostProcessorTests {
 
     private static final LogCaptor LOG_CAPTOR = LogCaptor.forClass(FormRequestPostProcessor.class);


### PR DESCRIPTION
- Upgrade Spring framework version to 6.2.8
- Set JDK and maven version to 21 / 3.9.9

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/f-lopes/spring-mvc-test-utils/332)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency ignore rules for automated dependency management.
  * Upgraded Java and Maven versions in the environment configuration.
  * Updated Spring Framework version to 6.2.8.

* **Tests**
  * Simplified test structure by removing nested test class annotation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->